### PR TITLE
feat: TODO-driven wake scheduling

### DIFF
--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -25,8 +25,9 @@ cryo clean [--force]                # Remove runtime files (logs, state, message
 These commands are used by the AI agent to communicate with the daemon. They send JSON messages over a Unix domain socket.
 
 ```bash
-cryo-agent hibernate --wake <ISO8601>  # Schedule next wake
-cryo-agent hibernate --complete        # Mark plan as complete
+cryo-agent hibernate --summary "..."   # End session (more work to do)
+cryo-agent hibernate --complete        # End session (plan done)
+cryo-agent todo add "text" --at <TIME> # Schedule next wake via TODO
 cryo-agent note "text"                 # Leave a note for next session
 cryo-agent send "message"             # Send message to human (writes to outbox)
 cryo-agent receive                     # Read inbox messages from human

--- a/docs/src/examples/mr-lazy.md
+++ b/docs/src/examples/mr-lazy.md
@@ -24,10 +24,12 @@ make check-agent
 
 ```
 Session 1: "What is the point of consciousness this early? It's only 09:15..."
-  → cryo-agent hibernate --wake 2026-03-08T09:18
+  → cryo-agent todo add "complain again" --at 2026-03-08T09:18
+  → cryo-agent hibernate --summary "Too early, going back to sleep"
 
 Session 2: "No hobbit ever woke up before second breakfast... and it's 09:18."
-  → cryo-agent hibernate --wake 2026-03-08T09:22
+  → cryo-agent todo add "maybe get up" --at 2026-03-08T09:22
+  → cryo-agent hibernate --summary "Still not ready, snoozing again"
 
 Session 3: "Fine. FINE. I'm up. Are you happy now?"
   → cryo-agent hibernate --complete --summary "Mr. Lazy finally got out of bed"

--- a/examples/mr-lazy/README.md
+++ b/examples/mr-lazy/README.md
@@ -27,10 +27,12 @@ make check-agent
 
 ```
 Session 1: "What is the point of consciousness this early? It's only 09:15..."
-  → cryo-agent hibernate --wake 2026-03-08T09:18
+  → cryo-agent todo add "complain again" --at 2026-03-08T09:18
+  → cryo-agent hibernate --summary "Too early, going back to sleep"
 
 Session 2: "No hobbit ever woke up before second breakfast... and it's 09:18."
-  → cryo-agent hibernate --wake 2026-03-08T09:22
+  → cryo-agent todo add "maybe get up" --at 2026-03-08T09:22
+  → cryo-agent hibernate --summary "Still not ready, snoozing again"
 
 Session 3: "Fine. FINE. I'm up. Are you happy now?"
   → cryo-agent hibernate --complete --summary "Mr. Lazy finally got out of bed"

--- a/examples/mr-lazy/plan.md
+++ b/examples/mr-lazy/plan.md
@@ -27,7 +27,7 @@ the same complaint twice. Draw inspiration from:
 4. Deliver a creative, unique complaint about being woken up.
    Reference the current time and how unreasonable it is.
 5. Compute the wake time using `cryo-agent time "+<N> minutes"`.
-6. Run `cryo-agent hibernate --wake <time>` to schedule the next wake.
+6. Run `cryo-agent todo add "next task" --at <time>` then `cryo-agent hibernate --summary "..."`.
 
 ## Notes
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -105,7 +105,7 @@ Follow the cryochamber protocol in CLAUDE.md or AGENTS.md. Read plan.md for the 
 
 ## Reminders
 
-- Use `cryo-agent hibernate` to end your session (--wake or --complete)
+- Use `cryo-agent hibernate` to end your session (--complete if plan is done)
 - Use `cryo-agent note` to leave context for your next session
 - Read plan.md before starting work
 "#,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -74,6 +74,7 @@ pub struct AgentConfig {
     pub session_number: u32,
     pub task: String,
     pub delayed_wake: Option<String>,
+    pub todo_list: String,
 }
 
 pub fn build_prompt(config: &AgentConfig) -> String {
@@ -98,20 +99,26 @@ Follow the cryochamber protocol in CLAUDE.md or AGENTS.md. Read plan.md for the 
 
 {task}
 
+## TODO List
+
+{todo_list}
+
 ## Context
 
-- Read cryo.log for previous session history
 - Check messages/inbox/ for new messages
 
 ## Reminders
 
-- Use `cryo-agent hibernate` to end your session (--complete if plan is done)
+- Use `cryo-agent todo add "text" --at TIME` to schedule work
+- Use `cryo-agent todo done <id>` to mark tasks complete
+- Use `cryo-agent hibernate` to end your session (--complete when plan is done)
 - Use `cryo-agent note` to leave context for your next session
 - Read plan.md before starting work
 "#,
         session_number = config.session_number,
         delayed = delayed_section,
         task = config.task,
+        todo_list = config.todo_list,
     )
 }
 

--- a/src/bin/cryo.rs
+++ b/src/bin/cryo.rs
@@ -403,6 +403,17 @@ fn cmd_status() -> Result<()> {
                 }
             );
             println!("Session: {}", st.session_number);
+
+            // Show next wake time from TODO list
+            let todo_path = dir.join("todo.json");
+            if let Ok(list) = cryochamber::todo::TodoList::load(&todo_path) {
+                if let Some(wake) = list.next_wake_time() {
+                    println!("Next wake: {wake}");
+                } else {
+                    println!("Next wake: idle (no pending TODOs)");
+                }
+            }
+
             if let Some(pid) = st.pid {
                 println!("PID: {pid}");
             }

--- a/src/bin/cryo.rs
+++ b/src/bin/cryo.rs
@@ -293,7 +293,6 @@ fn cmd_start(
         agent_override,
         max_retries_override,
         max_session_duration_override,
-        next_wake: None,
         last_report_time: None,
         provider_index: None,
     };

--- a/src/bin/cryo_agent.rs
+++ b/src/bin/cryo_agent.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 
 use cryochamber::message;
 use cryochamber::socket::{self, Request};
-use cryochamber::todo::TodoList;
 
 #[derive(Parser)]
 #[command(name = "cryo-agent", about = "Cryochamber agent IPC commands")]
@@ -18,9 +17,6 @@ struct Cli {
 enum Commands {
     /// End session and schedule next wake
     Hibernate {
-        /// Wake time in ISO8601 format
-        #[arg(long)]
-        wake: Option<String>,
         /// Mark plan as complete (no more wakes)
         #[arg(long)]
         complete: bool,
@@ -75,9 +71,9 @@ enum TodoAction {
     Add {
         /// Task description
         text: String,
-        /// Scheduled time (ISO8601)
+        /// Scheduled time (ISO8601) — required
         #[arg(long)]
-        at: Option<String>,
+        at: String,
     },
     /// List all TODO items
     List,
@@ -110,24 +106,17 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::Hibernate {
-            wake,
             complete,
             exit,
             summary,
-        } => {
-            if !complete && wake.is_none() {
-                anyhow::bail!("Either --wake or --complete is required");
-            }
-            send(
-                &dir,
-                &Request::Hibernate {
-                    wake,
-                    complete,
-                    exit_code: exit,
-                    summary,
-                },
-            )
-        }
+        } => send(
+            &dir,
+            &Request::Hibernate {
+                complete,
+                exit_code: exit,
+                summary,
+            },
+        ),
         Commands::Note { text } => send(&dir, &Request::Note { text }),
         Commands::Send { text } | Commands::Reply { text } => send(&dir, &Request::Reply { text }),
         Commands::Alert {
@@ -206,28 +195,10 @@ fn cmd_time(offset: Option<&str>) -> Result<()> {
 }
 
 fn cmd_todo(dir: &Path, action: TodoAction) -> Result<()> {
-    let path = dir.join("todo.json");
-    let mut list = TodoList::load(&path)?;
-
     match action {
-        TodoAction::Add { text, at } => {
-            let id = list.add(text, at);
-            list.save(&path)?;
-            println!("Added todo #{id}");
-        }
-        TodoAction::List => {
-            println!("{}", list.display());
-        }
-        TodoAction::Done { id } => {
-            list.done(id)?;
-            list.save(&path)?;
-            println!("Marked todo #{id} as done");
-        }
-        TodoAction::Remove { id } => {
-            list.remove(id)?;
-            list.save(&path)?;
-            println!("Removed todo #{id}");
-        }
+        TodoAction::Add { text, at } => send(dir, &Request::TodoAdd { text, at }),
+        TodoAction::List => send(dir, &Request::TodoList),
+        TodoAction::Done { id } => send(dir, &Request::TodoDone { id }),
+        TodoAction::Remove { id } => send(dir, &Request::TodoRemove { id }),
     }
-    Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -206,7 +206,7 @@ mod tests {
             agent_override: Some("claude".to_string()),
             max_retries_override: Some(10),
             max_session_duration_override: Some(300),
-            next_wake: None,
+
             last_report_time: None,
             provider_index: None,
         };
@@ -227,7 +227,7 @@ mod tests {
             agent_override: None,
             max_retries_override: None,
             max_session_duration_override: None,
-            next_wake: None,
+
             last_report_time: None,
             provider_index: None,
         };

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -299,7 +299,7 @@ impl Daemon {
         // Derive next wake from TODO list.
         let mut next_wake = next_wake_from_todos(&self.dir);
         let mut run_now = cryo_state.session_number == 0
-            || next_wake.map_or(false, |w| Local::now().naive_local() >= w);
+            || next_wake.is_some_and(|w| Local::now().naive_local() >= w);
         let mut inbox_wake = false;
         let mut pending_fallback: Option<(NaiveDateTime, FallbackAction)> = None;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -117,13 +117,8 @@ impl InboxWatcher {
 /// What the daemon should do after a session completes.
 pub enum SessionLoopOutcome {
     PlanComplete,
-    Hibernate {
-        wake_time: NaiveDateTime,
-        fallback: Option<FallbackAction>,
-    },
-    ValidationFailed {
-        quick_exit: bool,
-    },
+    Hibernate { fallback: Option<FallbackAction> },
+    ValidationFailed { quick_exit: bool },
 }
 
 /// Gracefully terminate a child process: SIGTERM, wait 2s, SIGKILL if needed.
@@ -155,24 +150,12 @@ fn compute_sleep_timeout(
     }
 }
 
-/// Restore the initial `(next_wake, run_now)` pair from persisted state.
-///
-/// - If `next_wake` is persisted and in the future → wait (don't run now).
-/// - If `next_wake` is persisted and in the past → run now (delayed wake check will fire).
-/// - If no `next_wake` → run immediately (fresh start).
-fn restore_wake_state(
-    state: &state::CryoState,
-    now: NaiveDateTime,
-) -> (Option<NaiveDateTime>, bool) {
-    let next_wake = state
-        .next_wake
-        .as_ref()
-        .and_then(|s| NaiveDateTime::parse_from_str(s, WAKE_TIME_FMT).ok());
-    let run_now = match next_wake {
-        Some(w) => now >= w,
-        None => true,
-    };
-    (next_wake, run_now)
+/// Compute the next wake time from the TODO list.
+fn next_wake_from_todos(dir: &Path) -> Option<NaiveDateTime> {
+    let path = dir.join("todo.json");
+    let list = crate::todo::TodoList::load(&path).ok()?;
+    let wake_str = list.next_wake_time()?;
+    NaiveDateTime::parse_from_str(wake_str, WAKE_TIME_FMT).ok()
 }
 
 /// Check if the scheduled wake time is significantly in the past (machine suspend).
@@ -313,9 +296,10 @@ impl Daemon {
 
         let provider_count = config.providers.len();
         let mut retry = RetryState::new(config.max_retries, provider_count);
-        // Restore persisted next_wake from state (survives daemon restart).
-        let (mut next_wake, mut run_now) =
-            restore_wake_state(&cryo_state, Local::now().naive_local());
+        // Derive next wake from TODO list.
+        let mut next_wake = next_wake_from_todos(&self.dir);
+        let mut run_now = cryo_state.session_number == 0
+            || next_wake.map_or(false, |w| Local::now().naive_local() >= w);
         let mut inbox_wake = false;
         let mut pending_fallback: Option<(NaiveDateTime, FallbackAction)> = None;
 
@@ -352,10 +336,7 @@ impl Daemon {
                     })
                 })
                 };
-                let saved_wake = next_wake.take();
-
                 cryo_state.session_number += 1;
-                cryo_state.next_wake = None;
                 if !config.providers.is_empty() {
                     cryo_state.provider_index = Some(retry.provider_index);
                 }
@@ -385,24 +366,24 @@ impl Daemon {
                                 eprintln!("Daemon: plan complete. Shutting down.");
                                 break;
                             }
-                            SessionLoopOutcome::Hibernate {
-                                wake_time,
-                                fallback,
-                            } => {
+                            SessionLoopOutcome::Hibernate { fallback } => {
                                 retry.reset();
-                                next_wake = Some(wake_time);
-                                cryo_state.next_wake =
-                                    Some(wake_time.format(WAKE_TIME_FMT).to_string());
+                                next_wake = next_wake_from_todos(&self.dir);
                                 let _ = state::save_state(&self.state_path, &cryo_state);
-                                pending_fallback =
-                                    fallback.map(|fb| (wake_time + chrono::Duration::hours(1), fb));
-                                eprintln!(
-                                    "Daemon: next wake at {}",
-                                    wake_time.format("%Y-%m-%d %H:%M")
-                                );
+                                pending_fallback = next_wake
+                                    .map(|w| (w + chrono::Duration::hours(1), fallback))
+                                    .and_then(|(deadline, fb)| fb.map(|f| (deadline, f)));
+                                if let Some(w) = next_wake {
+                                    eprintln!(
+                                        "Daemon: next wake at {}",
+                                        w.format("%Y-%m-%d %H:%M")
+                                    );
+                                } else {
+                                    eprintln!("Daemon: no pending TODOs, idling");
+                                }
                             }
                             SessionLoopOutcome::ValidationFailed { quick_exit } => {
-                                next_wake = saved_wake;
+                                next_wake = next_wake_from_todos(&self.dir);
 
                                 // Check if we should rotate provider
                                 let should_rotate = !config.providers.is_empty()
@@ -458,7 +439,7 @@ impl Daemon {
                     }
                     Err(e) => {
                         cryo_state.session_number -= 1;
-                        next_wake = saved_wake;
+                        next_wake = next_wake_from_todos(&self.dir);
                         eprintln!("Daemon: session failed: {e}");
                         if self.handle_failure_retry(&mut retry, &config.fallback_alert) {
                             break;
@@ -635,7 +616,6 @@ impl Daemon {
                             });
                         }
                         crate::socket::Request::Hibernate {
-                            wake,
                             complete,
                             exit_code,
                             summary,
@@ -646,26 +626,13 @@ impl Daemon {
                                     "hibernate: plan complete, exit={exit_code}, summary=\"{summary_str}\""
                                 ))?;
                                 hibernate_outcome = Some(SessionLoopOutcome::PlanComplete);
-                            } else if let Some(wake_str) = &wake {
-                                match chrono::NaiveDateTime::parse_from_str(wake_str, WAKE_TIME_FMT)
-                                {
-                                    Ok(wake_time) => {
-                                        logger.log_event(&format!(
-                                            "hibernate: wake={wake_str}, exit={exit_code}, summary=\"{summary_str}\""
-                                        ))?;
-                                        hibernate_outcome = Some(SessionLoopOutcome::Hibernate {
-                                            wake_time,
-                                            fallback: pending_fallback.take(),
-                                        });
-                                    }
-                                    Err(e) => {
-                                        let _ = responder.respond(&crate::socket::Response {
-                                            ok: false,
-                                            message: format!("Invalid wake time: {e}"),
-                                        });
-                                        continue;
-                                    }
-                                }
+                            } else {
+                                logger.log_event(&format!(
+                                    "hibernate: exit={exit_code}, summary=\"{summary_str}\""
+                                ))?;
+                                hibernate_outcome = Some(SessionLoopOutcome::Hibernate {
+                                    fallback: pending_fallback.take(),
+                                });
                             }
                             let _ = responder.respond(&crate::socket::Response {
                                 ok: true,
@@ -1170,85 +1137,40 @@ mod tests {
         assert_eq!(result.unwrap(), "6m");
     }
 
-    fn make_state(next_wake: Option<&str>) -> state::CryoState {
-        state::CryoState {
-            session_number: 1,
-            pid: None,
-            retry_count: 0,
-            next_wake: next_wake.map(String::from),
-            agent_override: None,
-            max_retries_override: None,
-            max_session_duration_override: None,
-            last_report_time: None,
-            provider_index: None,
-        }
-    }
-
     #[test]
-    fn test_restore_wake_state_no_persisted_wake() {
-        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap();
-        let state = make_state(None);
-        let (next_wake, run_now) = restore_wake_state(&state, now);
-        assert!(next_wake.is_none());
-        assert!(run_now, "No persisted wake → run immediately");
-    }
-
-    #[test]
-    fn test_restore_wake_state_future_wake() {
-        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
-            .unwrap()
-            .and_hms_opt(8, 0, 0)
-            .unwrap();
-        let state = make_state(Some("2026-03-01T09:00"));
-        let (next_wake, run_now) = restore_wake_state(&state, now);
+    fn test_next_wake_from_todos_picks_earliest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("todo.json");
+        let mut list = crate::todo::TodoList::new();
+        list.add("later".into(), "2026-03-02T16:00".into());
+        list.add("earlier".into(), "2026-03-02T14:00".into());
+        list.save(&path).unwrap();
+        let wake = next_wake_from_todos(dir.path());
         assert_eq!(
-            next_wake.unwrap(),
-            chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            wake.unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 2)
                 .unwrap()
-                .and_hms_opt(9, 0, 0)
+                .and_hms_opt(14, 0, 0)
                 .unwrap()
-        );
-        assert!(!run_now, "Wake in future → wait");
-    }
-
-    #[test]
-    fn test_restore_wake_state_past_wake() {
-        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap();
-        let state = make_state(Some("2026-03-01T09:00"));
-        let (next_wake, run_now) = restore_wake_state(&state, now);
-        assert!(next_wake.is_some(), "Should parse persisted wake");
-        assert!(
-            run_now,
-            "Wake in past → run now (delayed wake check will fire)"
         );
     }
 
     #[test]
-    fn test_restore_wake_state_exact_wake_time() {
-        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
-            .unwrap()
-            .and_hms_opt(9, 0, 0)
-            .unwrap();
-        let state = make_state(Some("2026-03-01T09:00"));
-        let (_, run_now) = restore_wake_state(&state, now);
-        assert!(run_now, "Exactly at wake time → run now");
+    fn test_next_wake_from_todos_none_when_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let wake = next_wake_from_todos(dir.path());
+        assert!(wake.is_none());
     }
 
     #[test]
-    fn test_restore_wake_state_invalid_format() {
-        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
-            .unwrap()
-            .and_hms_opt(12, 0, 0)
-            .unwrap();
-        let state = make_state(Some("not-a-date"));
-        let (next_wake, run_now) = restore_wake_state(&state, now);
-        assert!(next_wake.is_none(), "Invalid format → treated as no wake");
-        assert!(run_now, "Invalid format → run immediately");
+    fn test_next_wake_from_todos_skips_done() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("todo.json");
+        let mut list = crate::todo::TodoList::new();
+        let id = list.add("done".into(), "2026-03-02T10:00".into());
+        list.done(id).unwrap();
+        list.save(&path).unwrap();
+        let wake = next_wake_from_todos(dir.path());
+        assert!(wake.is_none());
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -151,11 +151,25 @@ fn compute_sleep_timeout(
 }
 
 /// Compute the next wake time from the TODO list.
+/// Iterates all pending TODOs, parses each `at` field, and returns the earliest
+/// valid timestamp. Invalid or unparseable entries are skipped with a warning.
 fn next_wake_from_todos(dir: &Path) -> Option<NaiveDateTime> {
     let path = dir.join("todo.json");
     let list = crate::todo::TodoList::load(&path).ok()?;
-    let wake_str = list.next_wake_time()?;
-    NaiveDateTime::parse_from_str(wake_str, WAKE_TIME_FMT).ok()
+    list.items()
+        .iter()
+        .filter(|i| !i.done && !i.at.is_empty())
+        .filter_map(|i| {
+            let parsed = NaiveDateTime::parse_from_str(&i.at, WAKE_TIME_FMT);
+            if parsed.is_err() {
+                eprintln!(
+                    "Daemon: Skipping TODO #{} with invalid at value: {:?}",
+                    i.id, i.at
+                );
+            }
+            parsed.ok()
+        })
+        .min()
 }
 
 /// Check if the scheduled wake time is significantly in the past (machine suspend).
@@ -526,9 +540,17 @@ impl Daemon {
 
         // Load TODO list for agent prompt
         let todo_path = self.dir.join("todo.json");
-        let todo_display = crate::todo::TodoList::load(&todo_path)
-            .map(|l| l.display())
-            .unwrap_or_else(|_| "No todos.".to_string());
+        let todo_display = match crate::todo::TodoList::load(&todo_path) {
+            Ok(list) => list.display(),
+            Err(err) => {
+                eprintln!(
+                    "Daemon: Error loading TODO list from {}: {}",
+                    todo_path.display(),
+                    err
+                );
+                format!("Error loading TODO list ({}). Please check todo.json.", err)
+            }
+        };
 
         // Build prompt with task context and TODO list
         let agent_config = crate::agent::AgentConfig {
@@ -1289,5 +1311,56 @@ mod tests {
         list.save(&path).unwrap();
         let wake = next_wake_from_todos(dir.path());
         assert!(wake.is_none());
+    }
+
+    #[test]
+    fn test_next_wake_from_todos_skips_invalid_and_picks_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("todo.json");
+        let mut list = crate::todo::TodoList::new();
+        // Invalid at value that sorts before valid ones
+        list.add("bad format".into(), "2026-03-02 10:00".into());
+        // Valid at value
+        list.add("valid task".into(), "2026-03-02T14:00".into());
+        list.save(&path).unwrap();
+        let wake = next_wake_from_todos(dir.path());
+        assert_eq!(
+            wake.unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 2)
+                .unwrap()
+                .and_hms_opt(14, 0, 0)
+                .unwrap(),
+            "Should skip invalid entry and pick valid one"
+        );
+    }
+
+    #[test]
+    fn test_next_wake_from_todos_skips_empty_at() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("todo.json");
+        // Simulate legacy items with empty `at` (from serde default)
+        let content = r#"[{"id":1,"text":"legacy item","done":false,"created":"unknown"},{"id":2,"text":"scheduled","done":false,"at":"2026-03-02T14:00","created":"unknown"}]"#;
+        std::fs::write(&path, content).unwrap();
+        let wake = next_wake_from_todos(dir.path());
+        assert_eq!(
+            wake.unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 2)
+                .unwrap()
+                .and_hms_opt(14, 0, 0)
+                .unwrap(),
+            "Should skip empty at and pick the valid one"
+        );
+    }
+
+    #[test]
+    fn test_next_wake_from_todos_all_invalid_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("todo.json");
+        let mut list = crate::todo::TodoList::new();
+        list.add("bad1".into(), "not-a-date".into());
+        list.add("bad2".into(), "also-bad".into());
+        list.save(&path).unwrap();
+        let wake = next_wake_from_todos(dir.path());
+        assert!(wake.is_none(), "All invalid entries should yield None");
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -685,11 +685,121 @@ impl Daemon {
                                 }
                             }
                         }
-                        _ => {
-                            let _ = responder.respond(&crate::socket::Response {
-                                ok: false,
-                                message: "Unknown command".into(),
-                            });
+                        crate::socket::Request::TodoAdd { text, at } => {
+                            let todo_path = self.dir.join("todo.json");
+                            match crate::todo::TodoList::load(&todo_path) {
+                                Ok(mut list) => {
+                                    let id = list.add(text.clone(), at.clone());
+                                    match list.save(&todo_path) {
+                                        Ok(()) => {
+                                            logger.log_event(&format!(
+                                                "todo add: #{id} \"{text}\" at {at}"
+                                            ))?;
+                                            let _ = responder.respond(&crate::socket::Response {
+                                                ok: true,
+                                                message: format!("Added todo #{id}"),
+                                            });
+                                        }
+                                        Err(e) => {
+                                            let _ = responder.respond(&crate::socket::Response {
+                                                ok: false,
+                                                message: format!("Failed to save todo: {e}"),
+                                            });
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    let _ = responder.respond(&crate::socket::Response {
+                                        ok: false,
+                                        message: format!("Failed to load todo list: {e}"),
+                                    });
+                                }
+                            }
+                        }
+                        crate::socket::Request::TodoDone { id } => {
+                            let todo_path = self.dir.join("todo.json");
+                            match crate::todo::TodoList::load(&todo_path) {
+                                Ok(mut list) => match list.done(id) {
+                                    Ok(()) => match list.save(&todo_path) {
+                                        Ok(()) => {
+                                            logger.log_event(&format!("todo done: #{id}"))?;
+                                            let _ = responder.respond(&crate::socket::Response {
+                                                ok: true,
+                                                message: format!("Marked todo #{id} as done"),
+                                            });
+                                        }
+                                        Err(e) => {
+                                            let _ = responder.respond(&crate::socket::Response {
+                                                ok: false,
+                                                message: format!("Failed to save todo: {e}"),
+                                            });
+                                        }
+                                    },
+                                    Err(e) => {
+                                        let _ = responder.respond(&crate::socket::Response {
+                                            ok: false,
+                                            message: format!("{e}"),
+                                        });
+                                    }
+                                },
+                                Err(e) => {
+                                    let _ = responder.respond(&crate::socket::Response {
+                                        ok: false,
+                                        message: format!("Failed to load todo list: {e}"),
+                                    });
+                                }
+                            }
+                        }
+                        crate::socket::Request::TodoRemove { id } => {
+                            let todo_path = self.dir.join("todo.json");
+                            match crate::todo::TodoList::load(&todo_path) {
+                                Ok(mut list) => match list.remove(id) {
+                                    Ok(()) => match list.save(&todo_path) {
+                                        Ok(()) => {
+                                            logger.log_event(&format!("todo remove: #{id}"))?;
+                                            let _ = responder.respond(&crate::socket::Response {
+                                                ok: true,
+                                                message: format!("Removed todo #{id}"),
+                                            });
+                                        }
+                                        Err(e) => {
+                                            let _ = responder.respond(&crate::socket::Response {
+                                                ok: false,
+                                                message: format!("Failed to save todo: {e}"),
+                                            });
+                                        }
+                                    },
+                                    Err(e) => {
+                                        let _ = responder.respond(&crate::socket::Response {
+                                            ok: false,
+                                            message: format!("{e}"),
+                                        });
+                                    }
+                                },
+                                Err(e) => {
+                                    let _ = responder.respond(&crate::socket::Response {
+                                        ok: false,
+                                        message: format!("Failed to load todo list: {e}"),
+                                    });
+                                }
+                            }
+                        }
+                        crate::socket::Request::TodoList => {
+                            let todo_path = self.dir.join("todo.json");
+                            match crate::todo::TodoList::load(&todo_path) {
+                                Ok(list) => {
+                                    let _ = responder.respond(&crate::socket::Response {
+                                        ok: true,
+                                        message: list.display(),
+                                    });
+                                }
+                                Err(e) => {
+                                    let _ = responder.respond(&crate::socket::Response {
+                                        ok: false,
+                                        message: format!("Failed to load todo list: {e}"),
+                                    });
+                                }
+                            }
                         }
                     }
                 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,7 +22,7 @@ use crate::config::CryoConfig;
 use crate::fallback::FallbackAction;
 use crate::state::{self, CryoState};
 
-/// Format for persisting `next_wake` in timer.json (minute precision, no seconds).
+/// Format for parsing TODO `at` timestamps (minute precision, no seconds).
 const WAKE_TIME_FMT: &str = "%Y-%m-%dT%H:%M";
 
 use crate::process::send_signal;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -334,7 +334,10 @@ impl Daemon {
                 // (e.g. computer was sleeping), notify the agent instead of failing.
                 // Skip this check for inbox-triggered wakes — the agent should handle
                 // the user's message without a spurious delay warning.
-                let delayed_wake = if is_inbox_wake { None } else { next_wake.and_then(|wake| {
+                let delayed_wake = if is_inbox_wake {
+                    None
+                } else {
+                    next_wake.and_then(|wake| {
                     let now = Local::now().naive_local();
                     detect_delayed_wake(wake, now).map(|delay_str| {
                         // Cancel premature fallback — the session is about to run
@@ -347,7 +350,8 @@ impl Daemon {
                             delay_str,
                         )
                     })
-                }) };
+                })
+                };
                 let saved_wake = next_wake.take();
 
                 cryo_state.session_number += 1;
@@ -713,6 +717,12 @@ impl Daemon {
                                     });
                                 }
                             }
+                        }
+                        _ => {
+                            let _ = responder.respond(&crate::socket::Response {
+                                ok: false,
+                                message: "Unknown command".into(),
+                            });
                         }
                     }
                 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -524,11 +524,18 @@ impl Daemon {
         // List inbox filenames for logging (agent reads files itself)
         let inbox_filenames: Vec<String> = crate::message::list_inbox(&self.dir)?;
 
-        // Build prompt (slim — agent reads cryo.log and inbox files directly)
+        // Load TODO list for agent prompt
+        let todo_path = self.dir.join("todo.json");
+        let todo_display = crate::todo::TodoList::load(&todo_path)
+            .map(|l| l.display())
+            .unwrap_or_else(|_| "No todos.".to_string());
+
+        // Build prompt with task context and TODO list
         let agent_config = crate::agent::AgentConfig {
             session_number: cryo_state.session_number,
             task: task.clone(),
             delayed_wake: delayed_wake.map(|s| s.to_string()),
+            todo_list: todo_display,
         };
         let prompt = crate::agent::build_prompt(&agent_config);
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -25,6 +25,17 @@ pub enum Request {
     Reply {
         text: String,
     },
+    TodoAdd {
+        text: String,
+        at: String,
+    },
+    TodoDone {
+        id: u32,
+    },
+    TodoRemove {
+        id: u32,
+    },
+    TodoList,
 }
 
 /// Response from daemon to CLI.
@@ -316,5 +327,39 @@ mod tests {
             Err(e) => panic!("Should not error for unknown fields: {e}"),
         }
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_todo_add_request_serialization() {
+        let req = Request::TodoAdd {
+            text: "Check CI".into(),
+            at: "2026-03-02T14:00".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"cmd\":\"todo_add\""));
+        assert!(json.contains("\"text\":\"Check CI\""));
+        assert!(json.contains("\"at\":\"2026-03-02T14:00\""));
+    }
+
+    #[test]
+    fn test_todo_done_request_serialization() {
+        let req = Request::TodoDone { id: 3 };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"cmd\":\"todo_done\""));
+        assert!(json.contains("\"id\":3"));
+    }
+
+    #[test]
+    fn test_todo_remove_request_serialization() {
+        let req = Request::TodoRemove { id: 5 };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"cmd\":\"todo_remove\""));
+    }
+
+    #[test]
+    fn test_todo_list_request_serialization() {
+        let req = Request::TodoList;
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"cmd\":\"todo_list\""));
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "cmd", rename_all = "snake_case")]
 pub enum Request {
     Hibernate {
-        wake: Option<String>,
         complete: bool,
         exit_code: u8,
         summary: Option<String>,
@@ -136,7 +135,6 @@ mod tests {
     #[test]
     fn test_serialize_hibernate_request() {
         let req = Request::Hibernate {
-            wake: Some("2026-03-08T09:00".to_string()),
             complete: false,
             exit_code: 0,
             summary: Some("Done".to_string()),

--- a/src/state.rs
+++ b/src/state.rs
@@ -17,9 +17,6 @@ pub struct CryoState {
     pub max_retries_override: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_session_duration_override: Option<u64>,
-    /// Scheduled next wake time (ISO 8601 format), set by daemon on hibernate.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub next_wake: Option<String>,
 
     /// Last time a periodic report was sent, stored as an ISO 8601 local time
     /// string without timezone offset (from `Local::now().naive_local()`).
@@ -117,7 +114,7 @@ mod tests {
             session_number: 1,
             pid: Some(pid),
             retry_count: 0,
-            next_wake: None,
+
             agent_override: None,
             max_retries_override: None,
             max_session_duration_override: None,
@@ -133,7 +130,7 @@ mod tests {
             session_number: 1,
             pid: None,
             retry_count: 0,
-            next_wake: None,
+
             agent_override: None,
             max_retries_override: None,
             max_session_duration_override: None,
@@ -149,7 +146,7 @@ mod tests {
             session_number: 1,
             pid: Some(std::process::id()),
             retry_count: 0,
-            next_wake: None,
+
             agent_override: None,
             max_retries_override: None,
             max_session_duration_override: None,

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -8,6 +8,7 @@ pub struct TodoItem {
     pub id: u32,
     pub text: String,
     pub done: bool,
+    #[serde(default)]
     pub at: String,
     #[serde(default = "default_created")]
     pub created: String,
@@ -99,10 +100,11 @@ impl TodoList {
     }
 
     /// Return the earliest `at` among pending (not done) items, if any.
+    /// Skips items with empty `at` (e.g. legacy items missing the field).
     pub fn next_wake_time(&self) -> Option<&str> {
         self.items
             .iter()
-            .filter(|i| !i.done)
+            .filter(|i| !i.done && !i.at.is_empty())
             .map(|i| i.at.as_str())
             .min()
     }
@@ -154,5 +156,30 @@ mod tests {
     fn test_next_wake_time_none_when_empty() {
         let list = TodoList::new();
         assert!(list.next_wake_time().is_none());
+    }
+
+    #[test]
+    fn test_backward_compat_missing_at_field() {
+        // Legacy JSON without the `at` field should deserialize with default empty string
+        let json = r#"[{"id":1,"text":"old item","done":false,"created":"unknown"}]"#;
+        let items: Vec<TodoItem> = serde_json::from_str(json).unwrap();
+        assert_eq!(items[0].at, "", "Missing at should default to empty string");
+    }
+
+    #[test]
+    fn test_next_wake_time_skips_empty_at() {
+        let mut list = TodoList::new();
+        // Simulate a legacy item with empty `at`
+        list.items.push(TodoItem {
+            id: 1,
+            text: "legacy".into(),
+            done: false,
+            at: "".into(),
+            created: "unknown".into(),
+        });
+        list.add("scheduled".into(), "2026-03-02T14:00".into());
+        // next_wake_time should skip empty `at` and return the scheduled item
+        let wake = list.next_wake_time();
+        assert_eq!(wake, Some("2026-03-02T14:00"));
     }
 }

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -2,14 +2,13 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-/// A single todo item with an ID, text, optional scheduled time, and completion status.
+/// A single todo item with an ID, text, scheduled time, and completion status.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TodoItem {
     pub id: u32,
     pub text: String,
     pub done: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub at: Option<String>,
+    pub at: String,
     #[serde(default = "default_created")]
     pub created: String,
 }
@@ -60,7 +59,7 @@ impl TodoList {
     }
 
     /// Add item. Returns the new item's ID.
-    pub fn add(&mut self, text: String, at: Option<String>) -> u32 {
+    pub fn add(&mut self, text: String, at: String) -> u32 {
         let id = self.items.iter().map(|i| i.id).max().unwrap_or(0) + 1;
         let created = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
         self.items.push(TodoItem {
@@ -93,14 +92,19 @@ impl TodoList {
             .iter()
             .map(|item| {
                 let check = if item.done { "x" } else { " " };
-                let at_suffix = match &item.at {
-                    Some(at) => format!(" (at: {at})"),
-                    None => String::new(),
-                };
-                format!("{}. [{}] {}{}", item.id, check, item.text, at_suffix)
+                format!("{}. [{}] {} (at: {})", item.id, check, item.text, item.at)
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    /// Return the earliest `at` among pending (not done) items, if any.
+    pub fn next_wake_time(&self) -> Option<&str> {
+        self.items
+            .iter()
+            .filter(|i| !i.done)
+            .map(|i| i.at.as_str())
+            .min()
     }
 
     /// Remove item. Returns error if ID not found.
@@ -112,5 +116,43 @@ impl TodoList {
             .with_context(|| format!("Todo item {id} not found"))?;
         self.items.remove(pos);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_next_wake_time_picks_earliest_pending() {
+        let mut list = TodoList::new();
+        list.add("later task".into(), "2026-03-02T16:00".into());
+        list.add("earlier task".into(), "2026-03-02T14:00".into());
+        let wake = list.next_wake_time();
+        assert_eq!(wake, Some("2026-03-02T14:00"));
+    }
+
+    #[test]
+    fn test_next_wake_time_skips_done_items() {
+        let mut list = TodoList::new();
+        let id = list.add("done task".into(), "2026-03-02T10:00".into());
+        list.done(id).unwrap();
+        list.add("pending task".into(), "2026-03-02T16:00".into());
+        let wake = list.next_wake_time();
+        assert_eq!(wake, Some("2026-03-02T16:00"));
+    }
+
+    #[test]
+    fn test_next_wake_time_none_when_all_done() {
+        let mut list = TodoList::new();
+        let id = list.add("task".into(), "2026-03-02T10:00".into());
+        list.done(id).unwrap();
+        assert!(list.next_wake_time().is_none());
+    }
+
+    #[test]
+    fn test_next_wake_time_none_when_empty() {
+        let list = TodoList::new();
+        assert!(list.next_wake_time().is_none());
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -441,6 +441,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_status_with_todo_wake() {
+        let dir = tempfile::tempdir().unwrap();
+        // Write a todo.json with a pending item that has a wake time
+        let todo_path = dir.path().join("todo.json");
+        let mut list = crate::todo::TodoList::new();
+        list.add("future task".into(), "2099-12-31T23:59".into());
+        list.save(&todo_path).unwrap();
+
+        // Write minimal cryo.toml
+        let config = crate::config::CryoConfig::default();
+        let config_path = dir.path().join("cryo.toml");
+        crate::config::save_config(&config_path, &config).unwrap();
+
+        let (tx, _rx) = tokio::sync::broadcast::channel::<SseEvent>(16);
+        let state = AppState {
+            project_dir: dir.path().to_path_buf(),
+            tx,
+        };
+        let resp = get_status(State(Arc::new(state))).await;
+        let status = &resp.0;
+        // next_wake should be present and contain the TODO's at time
+        let next_wake = status["next_wake"].as_str().unwrap();
+        assert!(
+            next_wake.contains("2099-12-31T23:59"),
+            "Status should show TODO-derived wake time, got: {next_wake}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_get_messages_empty() {
         let dir = tempfile::tempdir().unwrap();
         crate::message::ensure_dirs(dir.path()).unwrap();

--- a/src/web.rs
+++ b/src/web.rs
@@ -85,19 +85,27 @@ async fn get_status(State(state): State<Arc<AppState>>) -> Json<Value> {
         .flatten()
         .unwrap_or_default();
 
-    let (running, session, agent, next_wake) =
-        match state::load_state(&state::state_path(dir)).ok().flatten() {
-            Some(st) => {
-                let is_running = state::is_locked(&st);
-                let effective_agent = st
-                    .agent_override
-                    .as_deref()
-                    .unwrap_or(&cfg.agent)
-                    .to_string();
-                (is_running, st.session_number, effective_agent, st.next_wake)
-            }
-            None => (false, 0, cfg.agent.clone(), None),
-        };
+    let (running, session, agent) = match state::load_state(&state::state_path(dir)).ok().flatten()
+    {
+        Some(st) => {
+            let is_running = state::is_locked(&st);
+            let effective_agent = st
+                .agent_override
+                .as_deref()
+                .unwrap_or(&cfg.agent)
+                .to_string();
+            (is_running, st.session_number, effective_agent)
+        }
+        None => (false, 0, cfg.agent.clone()),
+    };
+
+    // Derive next wake from TODO list
+    let next_wake: Option<String> = {
+        let todo_path = dir.join("todo.json");
+        crate::todo::TodoList::load(&todo_path)
+            .ok()
+            .and_then(|list| list.next_wake_time().map(String::from))
+    };
 
     let log_file = log::log_path(dir);
 

--- a/templates/plan.md
+++ b/templates/plan.md
@@ -17,7 +17,8 @@ After 3 sessions, declare your journey complete.
    - Run `cryo-agent hibernate --complete --summary "Journey complete!"`
 5. Otherwise:
    - Compute a wake time 2 minutes from now: `cryo-agent time "+2 minutes"`
-   - Run `cryo-agent hibernate --wake <time> --summary "See you soon!"`
+   - Add a TODO: `cryo-agent todo add "next greeting" --at <time>`
+   - Run `cryo-agent hibernate --summary "See you soon!"`
 
 ## Notes
 

--- a/templates/plan.md
+++ b/templates/plan.md
@@ -18,7 +18,7 @@ After 3 sessions, declare your journey complete.
 5. Otherwise:
    - Compute a wake time 2 minutes from now: `cryo-agent time "+2 minutes"`
    - Add a TODO: `cryo-agent todo add "next greeting" --at <time>`
-   - Run `cryo-agent hibernate --summary "See you soon!"`
+   - Run `cryo-agent hibernate --summary "Session successful: <what was done>. Next: <what to do>"`
 
 ## Notes
 

--- a/templates/protocol.md
+++ b/templates/protocol.md
@@ -24,13 +24,23 @@ Execute these steps in order. **Do not skip or reorder steps.**
 - Leave notes for your future self: `cryo-agent note "what I did and what's next"`
 - Set up a dead-man switch if needed: `cryo-agent alert <action> <target> "message"`
 
-### Step 4: Hibernate (LAST action — nothing after this)
+### Step 4: Schedule next wake via TODO
+
+Add a TODO item with a scheduled time. The daemon derives its next wake from the earliest pending TODO.
+
+```
+cryo-agent todo add "description of next task" --at <TIME>
+```
+
+Use `cryo-agent time "+30 minutes"` to compute the `<TIME>` value.
+
+### Step 5: Hibernate (LAST action — nothing after this)
 
 Pick ONE of the following. **This must be your final tool call. Do not run any commands after it.** The daemon cannot archive messages or schedule the next wake until your process exits.
 
 **More work to do:**
 ```
-cryo-agent hibernate --wake <TIME> --summary "what I did, what's next"
+cryo-agent hibernate --summary "what I did, what's next"
 ```
 
 **All done:**
@@ -40,10 +50,8 @@ cryo-agent hibernate --complete --summary "All tasks finished"
 
 **Blocked or failed:**
 ```
-cryo-agent hibernate --wake <TIME> --exit 1 --summary "Blocked on X"
+cryo-agent hibernate --exit 1 --summary "Blocked on X"
 ```
-
-Use `cryo-agent time "+30 minutes"` to compute the `<TIME>` value before hibernating.
 
 ## Wake Time Guidelines
 

--- a/templates/protocol.md
+++ b/templates/protocol.md
@@ -70,8 +70,7 @@ cryo-agent send "message"                     # Send message to human (outbox)
 cryo-agent reply "message"                    # Reply to inbox messages
 cryo-agent receive                            # Read inbox messages from human
 cryo-agent alert <action> <target> "message"  # Dead-man switch (fires if you don't wake on time)
-cryo-agent todo add "text"                    # Add a TODO item
-cryo-agent todo add "text" --at 2026-03-05    # Add with scheduled time
+cryo-agent todo add "text" --at <TIME>        # Schedule a task (--at required)
 cryo-agent todo list                          # List all TODO items
 cryo-agent todo done <id>                     # Mark item as done
 cryo-agent todo remove <id>                   # Remove an item
@@ -81,6 +80,7 @@ cryo-agent time "+1 day"                      # Relative time computation
 
 ## Key Facts
 
+- **TODO list drives your schedule.** The daemon wakes at the earliest pending TODO's `at` time.
 - **Inbox messages wake you early.** Humans can send messages. You'll see them in your prompt.
 - **Notes survive across sessions.** Use `cryo-agent note` liberally — it's your memory.
 - **No hibernate = crash.** If you exit without calling `cryo-agent hibernate`, the daemon retries with backoff.

--- a/templates/protocol.md
+++ b/templates/protocol.md
@@ -26,7 +26,7 @@ Execute these steps in order. **Do not skip or reorder steps.**
 
 ### Step 4: Schedule next wake via TODO
 
-Add a TODO item with a scheduled time. The daemon derives its next wake from the earliest pending TODO.
+Based on what happened in this session and the plan, update the TODO list. Add a TODO item with a scheduled time for your next task. The daemon derives its next wake from the earliest pending TODO.
 
 ```
 cryo-agent todo add "description of next task" --at <TIME>

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -7,6 +7,7 @@ fn test_build_prompt_first_session() {
         session_number: 1,
         task: "Start the PR review plan".to_string(),
         delayed_wake: None,
+        todo_list: "No todos.".to_string(),
     };
     let prompt = build_prompt(&config);
     assert!(prompt.contains("Session number: 1"));
@@ -22,10 +23,11 @@ fn test_build_prompt_references_log() {
         session_number: 3,
         task: "Follow up on PRs".to_string(),
         delayed_wake: None,
+        todo_list: "No todos.".to_string(),
     };
     let prompt = build_prompt(&config);
     assert!(prompt.contains("Session number: 3"));
-    assert!(prompt.contains("cryo.log"));
+    assert!(prompt.contains("messages/inbox/"));
 }
 
 #[test]
@@ -34,6 +36,7 @@ fn test_build_prompt_contains_cli_reminders() {
         session_number: 1,
         task: "Do the thing".to_string(),
         delayed_wake: None,
+        todo_list: "No todos.".to_string(),
     };
     let prompt = build_prompt(&config);
     assert!(prompt.contains("cryo-agent hibernate"));
@@ -47,6 +50,7 @@ fn test_build_prompt_references_inbox() {
         session_number: 2,
         task: "Continue".to_string(),
         delayed_wake: None,
+        todo_list: "No todos.".to_string(),
     };
     let prompt = build_prompt(&config);
     assert!(prompt.contains("messages/inbox/"));
@@ -58,6 +62,7 @@ fn test_build_prompt_delayed_wake() {
         session_number: 4,
         task: "Check status".to_string(),
         delayed_wake: Some("DELAYED WAKE: 2h late".to_string()),
+        todo_list: "No todos.".to_string(),
     };
     let prompt = build_prompt(&config);
     assert!(prompt.contains("DELAYED WAKE: 2h late"));

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -687,7 +687,7 @@ fn test_session_logs_inbox_filenames() {
 fn test_agent_hibernate_no_daemon() {
     let dir = tempfile::tempdir().unwrap();
     agent_cmd()
-        .args(["hibernate", "--wake", "2099-01-01T00:00"])
+        .args(["hibernate", "--complete"])
         .current_dir(dir.path())
         .assert()
         .failure()
@@ -703,14 +703,4 @@ fn test_agent_note_no_daemon() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Cannot connect"));
-}
-
-#[test]
-fn test_agent_hibernate_requires_wake_or_complete() {
-    let dir = tempfile::tempdir().unwrap();
-    agent_cmd()
-        .args(["hibernate"])
-        .current_dir(dir.path())
-        .assert()
-        .failure();
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -65,7 +65,7 @@ fn test_apply_overrides_all() {
         agent_override: Some("claude".to_string()),
         max_retries_override: Some(10),
         max_session_duration_override: Some(7200),
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };
@@ -94,7 +94,7 @@ fn test_apply_overrides_none_keeps_config() {
         agent_override: None,
         max_retries_override: None,
         max_session_duration_override: None,
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };
@@ -125,7 +125,7 @@ fn test_apply_overrides_partial() {
         agent_override: Some("claude".to_string()),
         max_retries_override: None,
         max_session_duration_override: None,
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -34,10 +34,12 @@ fn test_build_prompt_with_context() {
         session_number: 3,
         task: "Continue work".to_string(),
         delayed_wake: None,
+        todo_list: "1. [ ] Review PR (at: 2026-03-02T14:00)".to_string(),
     };
     let prompt = build_prompt(&config);
     assert!(prompt.contains("Session number: 3"));
-    assert!(prompt.contains("cryo.log"));
+    assert!(prompt.contains("TODO List"));
+    assert!(prompt.contains("Review PR"));
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -52,7 +52,7 @@ fn test_state_roundtrip() {
         agent_override: Some("opencode".to_string()),
         max_retries_override: Some(3),
         max_session_duration_override: Some(1800),
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };

--- a/tests/mock_agent.sh
+++ b/tests/mock_agent.sh
@@ -13,7 +13,9 @@ fi
 
 # Default: hibernate --complete
 if [ "$MOCK_AGENT_COMPLETE" = "false" ] && [ -n "$MOCK_AGENT_WAKE" ]; then
-    "$CRYO_AGENT_BIN" hibernate --wake "$MOCK_AGENT_WAKE" --summary "${MOCK_AGENT_SUMMARY:-continuing}" 2>/dev/null || true
+    # Add a TODO with the wake time, then hibernate (not complete)
+    "$CRYO_AGENT_BIN" todo add "scheduled wake" --at "$MOCK_AGENT_WAKE" 2>/dev/null || true
+    "$CRYO_AGENT_BIN" hibernate --summary "${MOCK_AGENT_SUMMARY:-continuing}" 2>/dev/null || true
 else
     "$CRYO_AGENT_BIN" hibernate --complete --summary "${MOCK_AGENT_SUMMARY:-mock done}" 2>/dev/null || true
 fi

--- a/tests/mock_agent_tests.rs
+++ b/tests/mock_agent_tests.rs
@@ -278,16 +278,16 @@ fn test_mock_invalid_wake_time() {
         .assert()
         .success();
 
-    // Invalid wake time ("banana") is rejected by the daemon's NaiveDateTime parser.
-    // The daemon sends an error response but the agent script has already exited,
-    // so the daemon sees the agent exit without a successful hibernate call.
+    // The agent adds a TODO with "banana" as the time, then hibernates.
+    // The hibernate succeeds, but "banana" is unparseable as NaiveDateTime,
+    // so next_wake_from_todos returns None and the daemon idles.
     assert!(
         wait_for_log_content(
             dir.path(),
-            "agent exited without hibernate",
+            "no pending TODOs, idling",
             Duration::from_secs(15)
         ),
-        "Log should show agent exited without hibernate after invalid wake time"
+        "Daemon should idle since 'banana' is not a valid wake time"
     );
 
     cancel_and_wait(dir.path());
@@ -336,10 +336,8 @@ fn test_mock_double_hibernate() {
         .assert()
         .success();
 
-    // The script sends: hibernate --wake "+5 seconds", then hibernate --complete.
-    // "+5 seconds" is not valid ISO8601 (NaiveDateTime), so the daemon rejects
-    // the first hibernate. The second hibernate --complete succeeds, so the
-    // daemon completes the plan.
+    // The script sends two hibernate commands: first without --complete, then
+    // with --complete. The daemon takes the last one, so the plan completes.
     assert!(
         wait_for_log_content(dir.path(), "plan complete", Duration::from_secs(15)),
         "Log should show plan complete (first hibernate rejected, second succeeds)"
@@ -414,17 +412,12 @@ fn test_mock_hibernate_then_crash() {
         .assert()
         .success();
 
-    // The script sends: hibernate --wake "+5 seconds", then exit 1.
-    // "+5 seconds" is not valid ISO8601 (NaiveDateTime), so the daemon rejects
-    // the hibernate. The agent then exits with code 1, so the daemon sees it as
-    // "agent exited without hibernate" (a crash).
+    // The script sends: hibernate (not complete), then exit 1.
+    // The daemon accepts the hibernate, so despite the non-zero exit code,
+    // the session completes with the hibernate outcome.
     assert!(
-        wait_for_log_content(
-            dir.path(),
-            "agent exited without hibernate",
-            Duration::from_secs(15)
-        ),
-        "Log should show agent exited without hibernate (wake time was invalid)"
+        wait_for_log_content(dir.path(), "session complete", Duration::from_secs(15)),
+        "Log should show session complete (hibernate accepted despite crash)"
     );
 
     cancel_and_wait(dir.path());
@@ -949,9 +942,7 @@ fn test_invalid_report_time_warns() {
 fn write_inbox_message(dir: &std::path::Path, filename: &str, body: &str) {
     let inbox = dir.join("messages").join("inbox");
     fs::create_dir_all(&inbox).unwrap();
-    let content = format!(
-        "---\nfrom: test-user\nsubject: test\n---\n{body}"
-    );
+    let content = format!("---\nfrom: test-user\nsubject: test\n---\n{body}");
     fs::write(inbox.join(filename), content).unwrap();
 }
 
@@ -992,10 +983,7 @@ fn test_inbox_wake_coalesces_multiple_events() {
     );
 
     let log = fs::read_to_string(dir.path().join("cryo.log")).unwrap();
-    assert!(
-        log.contains("plan complete"),
-        "Plan should complete: {log}"
-    );
+    assert!(log.contains("plan complete"), "Plan should complete: {log}");
 
     // Only ONE session should have run (events coalesced)
     let session_count = log.matches("CRYO SESSION").count();
@@ -1031,9 +1019,9 @@ fn test_inbox_wake_no_delayed_wake_notice() {
         .assert()
         .success();
 
-    // Wait for session 1 to hibernate (it logs "hibernate: wake=...")
+    // Wait for session 1 to hibernate (logs "hibernate: exit=...")
     assert!(
-        wait_for_log_content(dir.path(), "hibernate: wake=", Duration::from_secs(10)),
+        wait_for_log_content(dir.path(), "hibernate: exit=", Duration::from_secs(10)),
         "Session 1 should hibernate with past wake time"
     );
 
@@ -1048,10 +1036,7 @@ fn test_inbox_wake_no_delayed_wake_notice() {
     );
 
     let log = fs::read_to_string(dir.path().join("cryo.log")).unwrap();
-    assert!(
-        log.contains("plan complete"),
-        "Plan should complete: {log}"
-    );
+    assert!(log.contains("plan complete"), "Plan should complete: {log}");
 
     // The key assertion: no "delayed wake" notice should appear.
     // Session 2 was triggered by inbox (InboxChanged queued during session 1),

--- a/tests/scenarios/delayed-wake.sh
+++ b/tests/scenarios/delayed-wake.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Mock agent: session 1 hibernates with a far-past wake time to trigger delayed wake detection.
-# Session 2 (the delayed wake) completes the plan.
+# Mock agent: session 1 hibernates with a far-past wake time via TODO to trigger
+# delayed wake detection. Session 2 (the delayed wake) completes the plan.
 # Uses a counter file to track sessions across invocations.
 
 COUNTER_FILE=".mock-session-count"
@@ -21,9 +21,10 @@ if [ "$COUNT" -ge 2 ]; then
     cryo-agent note "Session $COUNT: completing plan after delayed wake"
     cryo-agent hibernate --complete --summary "Plan completed after delayed wake"
 else
-    # Hibernate with a wake time 10 minutes in the past to trigger delayed wake detection.
+    # Add a TODO with a wake time 10 minutes in the past to trigger delayed wake detection.
     # The daemon will immediately wake and detect the delay.
     PAST_WAKE=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M 2>/dev/null || date -u -v-10M +%Y-%m-%dT%H:%M 2>/dev/null)
     cryo-agent note "Session $COUNT: hibernating with past wake time"
-    cryo-agent hibernate --wake "$PAST_WAKE" --summary "Session $COUNT done, testing delayed wake"
+    cryo-agent todo add "past wake" --at "$PAST_WAKE"
+    cryo-agent hibernate --summary "Session $COUNT done, testing delayed wake"
 fi

--- a/tests/scenarios/double-hibernate.sh
+++ b/tests/scenarios/double-hibernate.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
-cryo-agent hibernate --wake "+5 seconds"
+# First hibernate (not complete) — daemon accepts it
+cryo-agent hibernate --summary "first hibernate"
+# Second hibernate (complete) — overrides the first
 cryo-agent hibernate --complete

--- a/tests/scenarios/hibernate-then-crash.sh
+++ b/tests/scenarios/hibernate-then-crash.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
-cryo-agent hibernate --wake "+5 seconds"
+# Agent sends hibernate (not complete), then immediately crashes with exit 1.
+# Since the hibernate was accepted, the daemon should use the hibernate outcome
+# despite the non-zero exit code.
+cryo-agent hibernate --summary "about to crash"
 exit 1

--- a/tests/scenarios/inbox-delayed-wake.sh
+++ b/tests/scenarios/inbox-delayed-wake.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-# Mock agent: session 1 hibernates with a far-past wake time, sleeping briefly
-# to allow the test to write an inbox file during the session. Session 2 verifies
-# that inbox-triggered wake suppresses delayed wake detection.
+# Mock agent: session 1 hibernates with a far-past wake time via TODO, sleeping
+# briefly to allow the test to write an inbox file during the session. Session 2
+# verifies that inbox-triggered wake suppresses delayed wake detection.
 
 COUNTER_FILE=".mock-session-count"
 
@@ -18,9 +18,10 @@ if [ "$COUNT" -ge 2 ]; then
     cryo-agent note "Session $COUNT: completing after inbox wake"
     cryo-agent hibernate --complete --summary "Plan completed after inbox wake"
 else
-    # Hibernate with a wake time 10 minutes in the past.
+    # Add a TODO with a wake time 10 minutes in the past, then hibernate.
     PAST_WAKE=$(date -u -d '10 minutes ago' +%Y-%m-%dT%H:%M 2>/dev/null || date -u -v-10M +%Y-%m-%dT%H:%M 2>/dev/null)
-    cryo-agent hibernate --wake "$PAST_WAKE" --summary "Session $COUNT done"
+    cryo-agent todo add "past wake" --at "$PAST_WAKE"
+    cryo-agent hibernate --summary "Session $COUNT done"
     # Sleep after hibernate so the test can write an inbox file while this session
     # is still running. The InboxChanged event queues before the daemon's event loop
     # resumes, ensuring it takes priority over the timeout.

--- a/tests/scenarios/invalid-wake-time.sh
+++ b/tests/scenarios/invalid-wake-time.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-cryo-agent hibernate --wake "banana"
+# Agent adds a TODO with an invalid time format, then hibernates.
+# The TODO is saved as-is (validation happens at daemon wake time parsing).
+cryo-agent todo add "bad time" --at "banana"
+cryo-agent hibernate --summary "bad wake time"

--- a/tests/scenarios/multi-session.sh
+++ b/tests/scenarios/multi-session.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Mock agent: hibernates with short wake, completes on session 3.
+# Mock agent: hibernates with short wake via TODO, completes on session 3.
 # Tests: multi-session lifecycle through plan completion.
 # Uses a counter file to track sessions across invocations.
 
@@ -21,7 +21,9 @@ if [ "$COUNT" -ge 3 ]; then
     cryo-agent note "Session $COUNT: completing plan"
     cryo-agent hibernate --complete --summary "Plan completed after $COUNT sessions"
 else
-    WAKE=$(cryo-agent time "+2 seconds")
+    # Use current time (immediate wake) since we want the daemon to wake ASAP
+    WAKE=$(cryo-agent time)
     cryo-agent note "Session $COUNT: work in progress"
-    cryo-agent hibernate --wake "$WAKE" --summary "Session $COUNT done, more to do"
+    cryo-agent todo add "next session" --at "$WAKE"
+    cryo-agent hibernate --summary "Session $COUNT done, more to do"
 fi

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -13,7 +13,7 @@ fn test_save_and_load_state() {
         agent_override: Some("opencode test".to_string()),
         max_retries_override: None,
         max_session_duration_override: None,
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };
@@ -46,7 +46,7 @@ fn test_lock_mechanism() {
         agent_override: None,
         max_retries_override: None,
         max_session_duration_override: None,
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };
@@ -68,7 +68,7 @@ fn test_is_locked_dead_process() {
         agent_override: None,
         max_retries_override: None,
         max_session_duration_override: None,
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };
@@ -85,7 +85,7 @@ fn test_is_locked_no_pid() {
         agent_override: None,
         max_retries_override: None,
         max_session_duration_override: None,
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };
@@ -138,7 +138,7 @@ fn test_override_fields_roundtrip() {
         agent_override: Some("claude".to_string()),
         max_retries_override: Some(5),
         max_session_duration_override: Some(1800),
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };
@@ -161,7 +161,7 @@ fn test_none_overrides_not_serialized() {
         agent_override: None,
         max_retries_override: None,
         max_session_duration_override: None,
-        next_wake: None,
+
         last_report_time: None,
         provider_index: None,
     };
@@ -170,7 +170,6 @@ fn test_none_overrides_not_serialized() {
     assert!(!json.contains("agent_override"));
     assert!(!json.contains("max_retries_override"));
     assert!(!json.contains("max_session_duration_override"));
-    assert!(!json.contains("next_wake"));
     assert!(!json.contains("last_report_time"));
     assert!(!json.contains("provider_index"));
 }
@@ -186,7 +185,7 @@ fn test_last_report_time_roundtrip() {
         agent_override: None,
         max_retries_override: None,
         max_session_duration_override: None,
-        next_wake: None,
+
         last_report_time: Some("2026-02-28T09:00:00".to_string()),
         provider_index: None,
     };
@@ -203,30 +202,6 @@ fn test_last_report_time_roundtrip() {
 }
 
 #[test]
-fn test_next_wake_roundtrip() {
-    let dir = tempfile::tempdir().unwrap();
-    let state_path = dir.path().join("timer.json");
-    let state = CryoState {
-        session_number: 1,
-        pid: None,
-        retry_count: 0,
-        agent_override: None,
-        max_retries_override: None,
-        max_session_duration_override: None,
-        next_wake: Some("2026-03-01T09:00".to_string()),
-        last_report_time: None,
-        provider_index: None,
-    };
-    save_state(&state_path, &state).unwrap();
-    let loaded = load_state(&state_path).unwrap().unwrap();
-    assert_eq!(loaded.next_wake, Some("2026-03-01T09:00".to_string()));
-
-    // Verify it appears in JSON
-    let json = std::fs::read_to_string(&state_path).unwrap();
-    assert!(json.contains("next_wake"));
-}
-
-#[test]
 fn test_provider_index_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
     let state_path = dir.path().join("timer.json");
@@ -237,7 +212,7 @@ fn test_provider_index_roundtrip() {
         agent_override: None,
         max_retries_override: None,
         max_session_duration_override: None,
-        next_wake: None,
+
         last_report_time: None,
         provider_index: Some(2),
     };

--- a/tests/todo_tests.rs
+++ b/tests/todo_tests.rs
@@ -15,11 +15,8 @@ fn test_save_and_load_roundtrip() {
     let path = dir.path().join("todo.json");
 
     let mut list = TodoList::new();
-    list.add("First task".to_string(), None);
-    list.add(
-        "Second task".to_string(),
-        Some("2026-03-05T14:00".to_string()),
-    );
+    list.add("First task".to_string(), "2026-03-01T10:00".to_string());
+    list.add("Second task".to_string(), "2026-03-05T14:00".to_string());
     list.save(&path).unwrap();
 
     let loaded = TodoList::load(&path).unwrap();
@@ -27,10 +24,10 @@ fn test_save_and_load_roundtrip() {
     assert_eq!(loaded.items()[0].text, "First task");
     assert_eq!(loaded.items()[0].id, 1);
     assert!(!loaded.items()[0].done);
-    assert!(loaded.items()[0].at.is_none());
+    assert_eq!(loaded.items()[0].at, "2026-03-01T10:00");
     assert_eq!(loaded.items()[1].text, "Second task");
     assert_eq!(loaded.items()[1].id, 2);
-    assert_eq!(loaded.items()[1].at.as_deref(), Some("2026-03-05T14:00"));
+    assert_eq!(loaded.items()[1].at, "2026-03-05T14:00");
 }
 
 #[test]
@@ -39,7 +36,7 @@ fn test_save_is_compact_json() {
     let path = dir.path().join("todo.json");
 
     let mut list = TodoList::new();
-    list.add("Task".to_string(), None);
+    list.add("Task".to_string(), "2026-03-01T10:00".to_string());
     list.save(&path).unwrap();
 
     let content = std::fs::read_to_string(&path).unwrap();
@@ -52,9 +49,9 @@ fn test_save_is_compact_json() {
 #[test]
 fn test_add_assigns_incremental_ids() {
     let mut list = TodoList::new();
-    let id1 = list.add("A".to_string(), None);
-    let id2 = list.add("B".to_string(), None);
-    let id3 = list.add("C".to_string(), None);
+    let id1 = list.add("A".to_string(), "2026-03-01T10:00".to_string());
+    let id2 = list.add("B".to_string(), "2026-03-01T11:00".to_string());
+    let id3 = list.add("C".to_string(), "2026-03-01T12:00".to_string());
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
     assert_eq!(id3, 3);
@@ -63,7 +60,7 @@ fn test_add_assigns_incremental_ids() {
 #[test]
 fn test_done_marks_item_complete() {
     let mut list = TodoList::new();
-    let id = list.add("Task".to_string(), None);
+    let id = list.add("Task".to_string(), "2026-03-01T10:00".to_string());
     assert!(!list.items()[0].done);
     list.done(id).unwrap();
     assert!(list.items()[0].done);
@@ -80,7 +77,7 @@ fn test_done_nonexistent_id_returns_error() {
 #[test]
 fn test_done_already_done_is_idempotent() {
     let mut list = TodoList::new();
-    list.add("Task".to_string(), None);
+    list.add("Task".to_string(), "2026-03-01T10:00".to_string());
     list.done(1).unwrap();
     assert!(list.items()[0].done);
     // Calling done again should succeed silently
@@ -91,9 +88,9 @@ fn test_done_already_done_is_idempotent() {
 #[test]
 fn test_remove_deletes_item() {
     let mut list = TodoList::new();
-    list.add("A".to_string(), None);
-    let id2 = list.add("B".to_string(), None);
-    list.add("C".to_string(), None);
+    list.add("A".to_string(), "2026-03-01T10:00".to_string());
+    let id2 = list.add("B".to_string(), "2026-03-01T11:00".to_string());
+    list.add("C".to_string(), "2026-03-01T12:00".to_string());
     assert_eq!(list.items().len(), 3);
     list.remove(id2).unwrap();
     assert_eq!(list.items().len(), 2);
@@ -112,11 +109,11 @@ fn test_remove_nonexistent_id_returns_error() {
 #[test]
 fn test_id_assignment_after_removal() {
     let mut list = TodoList::new();
-    list.add("A".to_string(), None);
-    let id2 = list.add("B".to_string(), None);
+    list.add("A".to_string(), "2026-03-01T10:00".to_string());
+    let id2 = list.add("B".to_string(), "2026-03-01T11:00".to_string());
     list.remove(id2).unwrap();
     // Next ID should be max(existing) + 1 = 2, not 3
-    let id3 = list.add("C".to_string(), None);
+    let id3 = list.add("C".to_string(), "2026-03-01T12:00".to_string());
     assert_eq!(id3, 2);
 }
 
@@ -126,7 +123,7 @@ fn test_done_roundtrip_preserves_done_state() {
     let path = dir.path().join("todo.json");
 
     let mut list = TodoList::new();
-    list.add("Task".to_string(), None);
+    list.add("Task".to_string(), "2026-03-01T10:00".to_string());
     list.done(1).unwrap();
     list.save(&path).unwrap();
 
@@ -149,10 +146,10 @@ fn test_load_empty_list_roundtrip() {
 #[test]
 fn test_id_auto_increment_after_remove() {
     let mut list = TodoList::new();
-    list.add("A".to_string(), None);
-    list.add("B".to_string(), None);
+    list.add("A".to_string(), "2026-03-01T10:00".to_string());
+    list.add("B".to_string(), "2026-03-01T11:00".to_string());
     list.remove(1).unwrap(); // remove A (id=1)
-    let id = list.add("C".to_string(), None);
+    let id = list.add("C".to_string(), "2026-03-01T12:00".to_string());
     assert_eq!(id, 3, "ID should be max(existing)+1, not reuse removed IDs");
 }
 
@@ -161,13 +158,13 @@ fn test_display_formatting() {
     let mut list = TodoList::new();
     assert_eq!(list.display(), "No todos.");
 
-    list.add("First".to_string(), None);
-    list.add("Second".to_string(), Some("2026-03-05".to_string()));
+    list.add("First".to_string(), "2026-03-01T10:00".to_string());
+    list.add("Second".to_string(), "2026-03-05T14:00".to_string());
     list.done(1).unwrap();
 
     let output = list.display();
-    assert!(output.starts_with("1. [x] First\n"));
-    assert!(output.contains("2. [ ] Second (at: 2026-03-05)"));
+    assert!(output.starts_with("1. [x] First (at: 2026-03-01T10:00)\n"));
+    assert!(output.contains("2. [ ] Second (at: 2026-03-05T14:00)"));
 }
 
 fn agent_cmd() -> Command {

--- a/tests/todo_tests.rs
+++ b/tests/todo_tests.rs
@@ -172,106 +172,61 @@ fn agent_cmd() -> Command {
     Command::cargo_bin("cryo-agent").unwrap()
 }
 
+// CLI TODO tests — since TODO ops now go through the daemon socket,
+// these tests verify the no-daemon (connection error) behavior.
+
 #[test]
-fn test_cli_todo_add_and_list() {
+fn test_cli_todo_add_requires_at() {
     let dir = tempfile::tempdir().unwrap();
+    // --at is now required; omitting it should fail at CLI parse level
     agent_cmd()
         .args(["todo", "add", "Submit paper"])
         .current_dir(dir.path())
         .assert()
-        .success()
-        .stdout(predicates::str::contains("Added todo #1"));
+        .failure()
+        .stderr(predicates::str::contains("--at"));
+}
 
+#[test]
+fn test_cli_todo_add_no_daemon() {
+    let dir = tempfile::tempdir().unwrap();
+    agent_cmd()
+        .args(["todo", "add", "Submit paper", "--at", "2026-03-05T14:00"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Cannot connect"));
+}
+
+#[test]
+fn test_cli_todo_list_no_daemon() {
+    let dir = tempfile::tempdir().unwrap();
     agent_cmd()
         .args(["todo", "list"])
         .current_dir(dir.path())
         .assert()
-        .success()
-        .stdout(predicates::str::contains("1. [ ] Submit paper"));
+        .failure()
+        .stderr(predicates::str::contains("Cannot connect"));
 }
 
 #[test]
-fn test_cli_todo_add_with_at() {
+fn test_cli_todo_done_no_daemon() {
     let dir = tempfile::tempdir().unwrap();
-    agent_cmd()
-        .args(["todo", "add", "Check status", "--at", "2026-03-05T14:00"])
-        .current_dir(dir.path())
-        .assert()
-        .success();
-
-    agent_cmd()
-        .args(["todo", "list"])
-        .current_dir(dir.path())
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("(at: 2026-03-05T14:00)"));
-}
-
-#[test]
-fn test_cli_todo_done() {
-    let dir = tempfile::tempdir().unwrap();
-    agent_cmd()
-        .args(["todo", "add", "Task"])
-        .current_dir(dir.path())
-        .assert()
-        .success();
-
     agent_cmd()
         .args(["todo", "done", "1"])
         .current_dir(dir.path())
         .assert()
-        .success()
-        .stdout(predicates::str::contains("Marked todo #1 as done"));
-
-    agent_cmd()
-        .args(["todo", "list"])
-        .current_dir(dir.path())
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("1. [x] Task"));
+        .failure()
+        .stderr(predicates::str::contains("Cannot connect"));
 }
 
 #[test]
-fn test_cli_todo_remove() {
+fn test_cli_todo_remove_no_daemon() {
     let dir = tempfile::tempdir().unwrap();
-    agent_cmd()
-        .args(["todo", "add", "Task"])
-        .current_dir(dir.path())
-        .assert()
-        .success();
-
     agent_cmd()
         .args(["todo", "remove", "1"])
         .current_dir(dir.path())
         .assert()
-        .success()
-        .stdout(predicates::str::contains("Removed todo #1"));
-
-    agent_cmd()
-        .args(["todo", "list"])
-        .current_dir(dir.path())
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("No todos"));
-}
-
-#[test]
-fn test_cli_todo_done_nonexistent() {
-    let dir = tempfile::tempdir().unwrap();
-    agent_cmd()
-        .args(["todo", "done", "99"])
-        .current_dir(dir.path())
-        .assert()
-        .failure();
-}
-
-#[test]
-fn test_cli_todo_list_empty() {
-    let dir = tempfile::tempdir().unwrap();
-    agent_cmd()
-        .args(["todo", "list"])
-        .current_dir(dir.path())
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("No todos"));
+        .failure()
+        .stderr(predicates::str::contains("Cannot connect"));
 }


### PR DESCRIPTION
## Summary

- Replace `--wake TIME` on `cryo-agent hibernate` with TODO-driven wake scheduling
- The daemon now derives its next wake time from the earliest pending TODO item's `at` field
- All TODO operations (`add`, `done`, `remove`, `list`) route through daemon IPC via socket instead of local file I/O
- `TodoItem.at` is now required (was optional), ensuring every TODO has a scheduled time
- Agent prompt includes the current TODO list so the agent sees its schedule on wake
- `cryo status` displays the TODO-derived next wake time

## Test plan

- [x] All 306 tests pass (unit + integration + mock agent scenarios)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Mock agent scenarios updated to use TODO-based wake scheduling
- [x] All `cryo-agent hibernate --wake` references removed from code, tests, docs, and examples
- [x] Backward-compatible: old `timer.json` files with `next_wake` field are safely ignored by serde

🤖 Generated with [Claude Code](https://claude.com/claude-code)