### PR TITLE
fix: stabilize daemon lifecycle and startup recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+This repository keeps its agent instructions in [CLAUDE.md](./CLAUDE.md).
+
+Treat `CLAUDE.md` as the single source of truth for agent guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ make release V=x.y.z # tag and push a release (triggers CI publish to crates.io)
 | Binary | Purpose |
 |--------|---------|
 | `cryo` | Operator CLI — `init`, `start`, `status`, `cancel`, `log`, `watch`, `send`, `receive`, `wake`, `ps`, `restart`, `web`, `daemon` |
-| `cryo-agent` | Agent IPC CLI — `hibernate`, `note`, `send`, `reply`, `receive`, `alert`, `time`, `todo` (sends commands to daemon via socket; `receive`, `time`, and `todo` are local) |
+| `cryo-agent` | Agent IPC CLI — `hibernate`, `note`, `send`, `reply`, `receive`, `alert`, `time`, `todo` (most commands send requests to the daemon via socket; `receive` and `time` are local) |
 | `cryo-gh` | GitHub sync CLI — `init`, `pull`, `push`, `sync`, `unsync`, `status` (manages Discussion-based messaging via OS service) |
 | `cryo-zulip` | Zulip sync CLI — `init`, `pull`, `push`, `sync`, `unsync`, `status` (manages Zulip stream messaging via OS service) |
 
@@ -76,14 +76,14 @@ make release V=x.y.z # tag and push a release (triggers CI publish to crates.io)
 | `report` | Periodic session summary reports. Parses log, counts sessions/failures, sends desktop notification via notify-rust. |
 | `service` | OS service management: install/uninstall launchd (macOS) or systemd (Linux) user services. Used by `cryo start` and `cryo-gh sync` for reboot-persistent daemons. `CRYO_NO_SERVICE=1` disables (falls back to direct spawn). |
 | `gh_sync` | GitHub Discussion sync state persistence (`gh-sync.json`). |
-| `todo` | Per-project TODO list persistence (`todo.json`). `TodoItem`/`TodoList` structs, load/save, add/done/remove. Local only (no daemon IPC). |
+| `todo` | Per-project TODO list persistence (`todo.json`). `TodoItem`/`TodoList` structs, load/save, add/done/remove. Mutated through daemon IPC so scheduling changes are serialized with the session lifecycle. |
 | `zulip_sync` | Zulip sync state persistence (`zulip-sync.json`). |
 
 ### Key Design Decisions
 
 - **Daemon mode**: `cryo start` installs an OS service (launchd on macOS, systemd on Linux) that survives reboots. The daemon sleeps until the scheduled wake time, watches `messages/inbox/` for reactive wake, and enforces session timeout. Set `CRYO_NO_SERVICE=1` to fall back to direct background process spawn.
 - **Socket-based IPC**: The agent communicates with the daemon via `cryo-agent` CLI subcommands (`hibernate`, `note`, `send`, `alert`), which send JSON messages over a Unix domain socket. `receive` and `time` are local (no daemon needed).
-- **Fire-and-forget agent**: The daemon spawns the agent and redirects its stdout/stderr to `cryo-agent.log`. All structured communication flows through the socket.
+- **Fire-and-forget agent**: The daemon spawns the agent and redirects its stdout/stderr to `cryo-agent.log`. Stdout/stderr are diagnostic logs, not a human communication channel. All structured communication flows through `cryo-agent`.
 - **SIGUSR1 wake**: `cryo wake` and `cryo send --wake` send SIGUSR1 to the daemon PID, which works regardless of `watch_inbox` setting. The daemon's signal-forwarding thread converts this into an `InboxChanged` event.
 - **Config/state split**: `cryo.toml` is the project config (agent, retries, timeout, watch_inbox) created by `cryo init`. `timer.json` is runtime-only state (session number, PID, retry count, CLI overrides). CLI flags to `cryo start` are stored as optional overrides in `timer.json`.
 - **Preflight validation**: `cryo start` checks that the agent command exists on PATH before spawning.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ cargo install cryochamber
 
 This installs `cryo`, `cryo-agent`, `cryo-gh`, and `cryo-zulip` binaries.
 
+### Copy-Paste Onboarding Prompt
+
+If you want your coding agent to set up a new Cryochamber project for you, paste this:
+
+```text
+Set up a new Cryochamber project for me in this directory.
+
+1. If `cryo` is not installed, install it with `cargo install cryochamber` (or `cargo install --path .` if you are already in the cryochamber repo).
+2. If the `make-plan` skill is not installed, install it with `claude skill install --path skills/make-plan`.
+3. Invoke `/make-plan` to create the Cryochamber project and generate the initial plan/config files.
+4. Start the daemon with `cryo start`.
+5. Tell me which files were created or updated, and whether the service started successfully.
+```
+
 ### 2. Write your plan and configure
 
 Edit `plan.md` with your task — describe the goal, step-by-step tasks, and notes about persistent state. Edit `cryo.toml` to configure the agent command, retry policy, and inbox settings. See [`examples/`](examples/) for reference (chess-by-mail, mr-lazy).

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ If you want your coding agent to set up a new Cryochamber project for you, paste
 ```text
 Set up a new Cryochamber project for me in this directory.
 
-1. If `cryo` is not installed, install it with `cargo install cryochamber` (or `cargo install --path .` if you are already in the cryochamber repo).
-2. If the `make-plan` skill is not installed, install it with `claude skill install --path skills/make-plan`.
-3. Invoke `/make-plan` to create the Cryochamber project and generate the initial plan/config files.
+1. If `cryo` is not installed, install it with `cargo install cryochamber`.
+2. If the `make-plan` skill is not installed and your coding agent supports custom skills, install it from the Cryochamber repo: clone https://github.com/GiggleLiu/cryochamber somewhere local, then use your agent's skill installation mechanism to install `/path/to/cryochamber/skills/make-plan`.
+3. Invoke the `make-plan` skill to create the Cryochamber project and generate the initial plan/config files.
 4. Start the daemon with `cryo start`.
 5. Tell me which files were created or updated, and whether the service started successfully.
 ```
@@ -41,11 +41,11 @@ Set up a new Cryochamber project for me in this directory.
 
 Edit `plan.md` with your task — describe the goal, step-by-step tasks, and notes about persistent state. Edit `cryo.toml` to configure the agent command, retry policy, and inbox settings. See [`examples/`](examples/) for reference (chess-by-mail, mr-lazy).
 
-**Recommended:** Tell your AI coding agent to install the skill:
+**Recommended:** If your AI coding agent supports custom skills, install `make-plan` from the Cryochamber repo:
 
 > Add the make-plan skill from https://github.com/GiggleLiu/cryochamber
 
-Then run `/make-plan` to create a new project interactively via guided Q&A.
+Then invoke the `make-plan` skill to create a new project interactively via guided Q&A.
 
 ### 3. Start the service
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -9,7 +9,7 @@
 | Binary | Purpose |
 |--------|---------|
 | `cryo` | Operator CLI — `init`, `start`, `status`, `cancel`, `log`, `watch`, `send`, `receive`, `wake`, `ps`, `restart`, `daemon` |
-| `cryo-agent` | Agent IPC CLI — `hibernate`, `note`, `send`, `receive`, `alert`, `time` (sends commands to daemon via socket; `receive` and `time` are local) |
+| `cryo-agent` | Agent IPC CLI — `hibernate`, `note`, `send`, `reply`, `receive`, `alert`, `time`, `todo` (most commands send requests to daemon via socket; `receive` and `time` are local) |
 | `cryo-gh` | GitHub sync CLI — `init`, `pull`, `push`, `sync`, `unsync`, `status` (manages Discussion-based messaging via OS service) |
 
 ## Modules
@@ -36,7 +36,7 @@
 
 - **Daemon mode**: `cryo start` installs an OS service (launchd on macOS, systemd on Linux) that survives reboots. The daemon sleeps until the scheduled wake time, watches `messages/inbox/` for reactive wake, and enforces session timeout. Set `CRYO_NO_SERVICE=1` to fall back to direct background process spawn.
 - **Socket-based IPC**: The agent communicates with the daemon via `cryo-agent` CLI subcommands (`hibernate`, `note`, `send`, `alert`), which send JSON messages over a Unix domain socket. `receive` and `time` are local (no daemon needed).
-- **Fire-and-forget agent**: The daemon spawns the agent and redirects its stdout/stderr to `cryo-agent.log`. All structured communication flows through the socket.
+- **Fire-and-forget agent**: The daemon spawns the agent and redirects its stdout/stderr to `cryo-agent.log`. Stdout/stderr are diagnostic logs, not a human communication channel. All structured communication flows through `cryo-agent`.
 - **SIGUSR1 wake**: `cryo wake` and `cryo send --wake` send SIGUSR1 to the daemon PID, which works regardless of `watch_inbox` setting. The daemon's signal-forwarding thread converts this into an `InboxChanged` event.
 - **Config/state split**: `cryo.toml` is the project config (agent, retries, timeout, watch_inbox) created by `cryo init`. `timer.json` is runtime-only state (session number, PID, retry count, CLI overrides). CLI flags to `cryo start` are stored as optional overrides in `timer.json`.
 - **Graceful degradation**: If the agent exits without calling `cryo-agent hibernate`, the daemon treats it as a crash and retries with backoff. EventLogger is always finalized even on error.

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -23,10 +23,12 @@ cryo clean [--force]                # Remove runtime files (logs, state, message
 ## Agent IPC (`cryo-agent`)
 
 These commands are used by the AI agent to communicate with the daemon. They send JSON messages over a Unix domain socket.
+Human-visible communication should go through `cryo-agent send` / `cryo-agent reply`; stdout/stderr are only written to `cryo-agent.log`.
 
 ```bash
 cryo-agent hibernate --summary "..."   # End session (more work to do)
 cryo-agent hibernate --complete        # End session (plan done)
+cryo-agent hibernate --exit 1          # Retryable failure (daemon retries)
 cryo-agent todo add "text" --at <TIME> # Schedule next wake via TODO
 cryo-agent note "text"                 # Leave a note for next session
 cryo-agent send "message"             # Send message to human (writes to outbox)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -5,7 +5,7 @@
 ```toml
 # cryo.toml — Cryochamber project configuration
 agent = "opencode"        # Agent command (opencode, claude, codex, etc.)
-max_retries = 1           # Max retry attempts on agent failure (1 = no retry)
+max_retries = 5           # Failed attempts before retry alerting (daemon keeps retrying)
 max_session_duration = 0  # Session timeout in seconds (0 = no timeout)
 watch_inbox = true        # Watch inbox for reactive wake
 
@@ -19,7 +19,7 @@ watch_inbox = true        # Watch inbox for reactive wake
 | Field | Default | Description |
 |-------|---------|-------------|
 | `agent` | `"opencode"` | Agent command to run. Use `"claude"` for Claude Code, `"codex"` for Codex. |
-| `max_retries` | `1` | Max retry attempts on agent failure. `1` means no retry. |
+| `max_retries` | `5` | Failed attempts before sending a retry alert. The daemon continues retrying with backoff. |
 | `max_session_duration` | `0` | Session timeout in seconds. `0` disables timeout. |
 | `watch_inbox` | `true` | Watch `messages/inbox/` for new files and wake immediately. |
 | `web_host` | `"127.0.0.1"` | Host for `cryo web` to listen on. Use `"0.0.0.0"` for remote access only behind an authenticated, TLS-terminating proxy. |

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -106,12 +106,15 @@ Follow the cryochamber protocol in CLAUDE.md or AGENTS.md. Read plan.md for the 
 ## Context
 
 - Check messages/inbox/ for new messages
+- The only supported way to communicate with the human is `cryo-agent send` / `cryo-agent reply`
+- Stdout/stderr go to `cryo-agent.log`; they are not a user conversation channel
 
 ## Reminders
 
 - Use `cryo-agent todo add "text" --at TIME` to schedule work
 - Use `cryo-agent todo done <id>` to mark tasks complete
 - Use `cryo-agent hibernate` to end your session (--complete when plan is done)
+- Use `cryo-agent hibernate --exit 1` only for genuine retryable failure
 - Use `cryo-agent note` to leave context for your next session
 - Read plan.md before starting work
 "#,
@@ -131,7 +134,9 @@ pub fn build_command(agent_command: &str, prompt: &str) -> Result<Command> {
 
     match kind {
         AgentKind::Claude => {
-            cmd.arg("-p");
+            if !args.iter().any(|arg| arg == "-p") {
+                cmd.arg("-p");
+            }
         }
         AgentKind::Opencode | AgentKind::Codex | AgentKind::Custom | AgentKind::Mock => {}
     }

--- a/src/bin/cryo.rs
+++ b/src/bin/cryo.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use cryochamber::config;
 use cryochamber::message;
 use cryochamber::protocol;
+use cryochamber::socket::{self, Request};
 use cryochamber::state::{self, CryoState};
 
 #[derive(Parser)]
@@ -28,7 +29,7 @@ enum Commands {
         /// Agent command to use (overrides cryo.toml)
         #[arg(long)]
         agent: Option<String>,
-        /// Max retry attempts on agent spawn failure (overrides cryo.toml)
+        /// Failed attempts before alerting (daemon keeps retrying with backoff)
         #[arg(long)]
         max_retries: Option<u32>,
         /// Maximum session duration in seconds (overrides cryo.toml)
@@ -184,7 +185,7 @@ fn require_live_daemon(dir: &Path) -> Result<CryoState> {
     require_valid_project(dir)?;
     let cryo_state = state::load_state(&state::state_path(dir))?
         .context("No daemon state found. Run `cryo start` first.")?;
-    if !state::is_locked(&cryo_state) {
+    if !state::is_locked(&cryo_state) || !daemon_responding(dir) {
         anyhow::bail!(
             "No live daemon in this directory (stale state from a previous run). \
              Run `cryo start` to start a new one, or `cryo cancel` to clean up stale state."
@@ -248,6 +249,43 @@ fn validate_agent_command(agent_cmd: &str) -> Result<()> {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DaemonLaunchMode {
+    BackgroundProcess,
+    Service,
+}
+
+fn launch_daemon(dir: &Path) -> Result<DaemonLaunchMode> {
+    if std::env::var("CRYO_NO_SERVICE").is_ok() {
+        cryochamber::process::spawn_daemon(dir)?;
+        Ok(DaemonLaunchMode::BackgroundProcess)
+    } else {
+        let exe = std::env::current_exe().context("Failed to resolve cryo executable path")?;
+        let log_path = cryochamber::log::log_path(dir);
+        cryochamber::service::install("daemon", dir, &exe, &["daemon"], &log_path, false)?;
+        Ok(DaemonLaunchMode::Service)
+    }
+}
+
+fn daemon_responding(dir: &Path) -> bool {
+    matches!(socket::send_request(dir, &Request::Ping), Ok(resp) if resp.ok)
+}
+
+fn wait_for_live_daemon(dir: &Path) -> Result<()> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if let Some(st) = state::load_state(&state::state_path(dir))? {
+            if state::is_locked(&st) && daemon_responding(dir) {
+                return Ok(());
+            }
+        }
+        if std::time::Instant::now() > deadline {
+            anyhow::bail!("Daemon did not start within 10 seconds. Check cryo.log for errors.");
+        }
+    }
+}
+
 fn cmd_start(
     agent_override: Option<String>,
     max_retries_override: Option<u32>,
@@ -295,31 +333,20 @@ fn cmd_start(
         max_session_duration_override,
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
     state::save_state(&state::state_path(&dir), &cryo_state)?;
 
-    // CRYO_NO_SERVICE=1 disables OS service installation (useful for tests / debugging)
-    if std::env::var("CRYO_NO_SERVICE").is_ok() {
-        cryochamber::process::spawn_daemon(&dir)?;
-        println!("Cryochamber started (background process).");
-    } else {
-        let exe = std::env::current_exe().context("Failed to resolve cryo executable path")?;
-        let log_path = cryochamber::log::log_path(&dir);
-        cryochamber::service::install("daemon", &dir, &exe, &["daemon"], &log_path, false)?;
-        println!("Cryochamber started (service installed, survives reboot).");
-    }
+    let launch_mode = launch_daemon(&dir)?;
+    wait_for_live_daemon(&dir)?;
 
-    // Wait for the daemon to write its PID before returning
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-    loop {
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        if let Some(st) = state::load_state(&state::state_path(&dir))? {
-            if state::is_locked(&st) {
-                break;
-            }
+    match launch_mode {
+        DaemonLaunchMode::BackgroundProcess => {
+            println!("Cryochamber started (background process).")
         }
-        if std::time::Instant::now() > deadline {
-            anyhow::bail!("Daemon did not start within 10 seconds. Check cryo.log for errors.");
+        DaemonLaunchMode::Service => {
+            println!("Cryochamber started (service installed, survives reboot).")
         }
     }
 
@@ -478,11 +505,13 @@ fn cmd_restart() -> Result<()> {
     };
     state::save_state(&state::state_path(&dir), &updated)?;
 
-    let exe = std::env::current_exe().context("Failed to resolve cryo executable path")?;
-    let log_path = cryochamber::log::log_path(&dir);
-    cryochamber::service::install("daemon", &dir, &exe, &["daemon"], &log_path, false)?;
+    let launch_mode = launch_daemon(&dir)?;
+    wait_for_live_daemon(&dir)?;
 
-    println!("Restarted (service reinstalled).");
+    match launch_mode {
+        DaemonLaunchMode::BackgroundProcess => println!("Restarted (background process)."),
+        DaemonLaunchMode::Service => println!("Restarted (service reinstalled)."),
+    }
     println!("Use `cryo watch` or `cryo web` to follow progress.");
     Ok(())
 }
@@ -527,7 +556,7 @@ fn cmd_cancel() -> Result<()> {
         }
         Some(cryo_state) => {
             // Kill daemon process if still alive
-            if state::is_locked(&cryo_state) {
+            if state::is_locked(&cryo_state) && daemon_responding(&dir) {
                 if let Some(pid) = cryo_state.pid {
                     cryochamber::process::terminate_pid(pid)?;
                     println!("Killed daemon (PID {pid}).");
@@ -579,7 +608,7 @@ fn cmd_clean(force: bool) -> Result<()> {
     // Kill daemon process if still running
     let sp = state::state_path(&dir);
     if let Some(cryo_state) = state::load_state(&sp)? {
-        if state::is_locked(&cryo_state) {
+        if state::is_locked(&cryo_state) && daemon_responding(&dir) {
             if let Some(pid) = cryo_state.pid {
                 cryochamber::process::terminate_pid(pid)?;
                 println!("Killed daemon (PID {pid}).");
@@ -645,7 +674,7 @@ fn build_inbox_message(from: &str, subject: &str, body: &str) -> message::Messag
 /// Check if a daemon is running in the given directory.
 fn is_daemon_running(dir: &std::path::Path) -> bool {
     if let Ok(Some(st)) = state::load_state(&state::state_path(dir)) {
-        return state::is_locked(&st);
+        return state::is_locked(&st) && daemon_responding(dir);
     }
     false
 }

--- a/src/bin/cryo_agent.rs
+++ b/src/bin/cryo_agent.rs
@@ -20,7 +20,7 @@ enum Commands {
         /// Mark plan as complete (no more wakes)
         #[arg(long)]
         complete: bool,
-        /// Exit code: 0=success, 1=partial, 2=failure
+        /// Exit code: 0=success, nonzero=failure (daemon retries)
         #[arg(long, default_value = "0")]
         exit: u8,
         /// Human-readable session summary

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ pub struct CryoConfig {
     #[serde(default = "default_agent")]
     pub agent: String,
 
-    /// Max retry attempts on agent failure (0 = no retry)
+    /// Failed attempts before sending a retry alert. The daemon keeps retrying.
     #[serde(default = "default_max_retries")]
     pub max_retries: u32,
 
@@ -209,6 +209,8 @@ mod tests {
 
             last_report_time: None,
             provider_index: None,
+            instance_id: None,
+            pending_fallback: None,
         };
         config.apply_overrides(&state);
         assert_eq!(config.agent, "claude");
@@ -230,6 +232,8 @@ mod tests {
 
             last_report_time: None,
             provider_index: None,
+            instance_id: None,
+            pending_fallback: None,
         };
         config.apply_overrides(&state);
         assert_eq!(config.agent, original.agent);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -16,16 +16,39 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::config::CryoConfig;
 use crate::fallback::FallbackAction;
-use crate::state::{self, CryoState};
+use crate::state::{self, CryoState, PendingFallbackState};
 
 /// Format for parsing TODO `at` timestamps (minute precision, no seconds).
 const WAKE_TIME_FMT: &str = "%Y-%m-%dT%H:%M";
+const FALLBACK_TIME_FMT: &str = "%Y-%m-%dT%H:%M:%S";
 
 use crate::process::send_signal;
+
+trait Clock: Send + Sync {
+    fn local_now(&self) -> NaiveDateTime;
+    fn monotonic_now(&self) -> Instant;
+    fn sleep(&self, duration: Duration);
+}
+
+struct SystemClock;
+
+impl Clock for SystemClock {
+    fn local_now(&self) -> NaiveDateTime {
+        Local::now().naive_local()
+    }
+
+    fn monotonic_now(&self) -> Instant {
+        Instant::now()
+    }
+
+    fn sleep(&self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
+}
 
 /// Events the daemon responds to.
 #[derive(Debug, PartialEq)]
@@ -34,6 +57,62 @@ pub enum DaemonEvent {
     InboxChanged,
     /// SIGTERM or SIGINT received.
     Shutdown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WaitError {
+    Timeout,
+    Disconnected,
+}
+
+trait EventSource {
+    fn recv_timeout(&self, timeout: Duration) -> Result<DaemonEvent, WaitError>;
+    fn drain_inbox_changed(&self);
+}
+
+impl EventSource for mpsc::Receiver<DaemonEvent> {
+    fn recv_timeout(&self, timeout: Duration) -> Result<DaemonEvent, WaitError> {
+        self.recv_timeout(timeout).map_err(Into::into)
+    }
+
+    fn drain_inbox_changed(&self) {
+        while matches!(self.try_recv(), Ok(DaemonEvent::InboxChanged)) {}
+    }
+}
+
+impl From<mpsc::RecvTimeoutError> for WaitError {
+    fn from(value: mpsc::RecvTimeoutError) -> Self {
+        match value {
+            mpsc::RecvTimeoutError::Timeout => Self::Timeout,
+            mpsc::RecvTimeoutError::Disconnected => Self::Disconnected,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdleWaitOutcome {
+    WakeFromInbox,
+    WakeFromSchedule,
+    Shutdown,
+    Disconnected,
+    StayIdle,
+}
+
+fn wait_for_idle_event(
+    source: &impl EventSource,
+    timeout: Duration,
+    has_scheduled_wake: bool,
+) -> IdleWaitOutcome {
+    match source.recv_timeout(timeout) {
+        Ok(DaemonEvent::InboxChanged) => {
+            source.drain_inbox_changed();
+            IdleWaitOutcome::WakeFromInbox
+        }
+        Ok(DaemonEvent::Shutdown) => IdleWaitOutcome::Shutdown,
+        Err(WaitError::Timeout) if has_scheduled_wake => IdleWaitOutcome::WakeFromSchedule,
+        Err(WaitError::Timeout) => IdleWaitOutcome::StayIdle,
+        Err(WaitError::Disconnected) => IdleWaitOutcome::Disconnected,
+    }
 }
 
 /// Tracks retry state with exponential backoff.
@@ -115,16 +194,360 @@ impl InboxWatcher {
 }
 
 /// What the daemon should do after a session completes.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionLoopOutcome {
     PlanComplete,
     Hibernate { fallback: Option<FallbackAction> },
     ValidationFailed { quick_exit: bool },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionInterruption {
+    Shutdown,
+    Timeout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HibernateDecision {
+    outcome: SessionLoopOutcome,
+    response_message: &'static str,
+    log_event: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InterruptedSessionDecision {
+    outcome: SessionLoopOutcome,
+    finish_reason: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChildExitDecision {
+    outcome: SessionLoopOutcome,
+    finish_reason: &'static str,
+    quick_exit: bool,
+}
+
+struct ActiveSessionContext<'a> {
+    cryo_state: &'a CryoState,
+    timeout_secs: u64,
+    spawn_time: Instant,
+    inbox_filenames: &'a [String],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DaemonBootstrapState {
+    next_report_time: Option<NaiveDateTime>,
+    next_wake: Option<NaiveDateTime>,
+    run_now: bool,
+    pending_fallback: Option<(NaiveDateTime, FallbackAction)>,
+    watch_inbox_path: Option<PathBuf>,
+    cleared_invalid_pending_fallback: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ChildExitStatus {
+    code: Option<i32>,
+}
+
+trait SessionRuntime {
+    fn accept_request(
+        &mut self,
+        expected_instance_id: Option<&str>,
+    ) -> Result<Option<crate::socket::Request>>;
+    fn respond(&mut self, ok: bool, message: String) -> Result<()>;
+    fn try_wait(&mut self) -> std::io::Result<Option<ChildExitStatus>>;
+    fn terminate(&mut self);
+}
+
+trait SessionEffects {
+    fn archive_inbox(&mut self, inbox_filenames: &[String]) -> Result<()>;
+    fn write_reply(&mut self, text: &str, timestamp: NaiveDateTime) -> Result<()>;
+    fn todo_add(&mut self, text: &str, at: &str) -> Result<u32>;
+    fn todo_done(&mut self, id: u32) -> Result<()>;
+    fn todo_remove(&mut self, id: u32) -> Result<()>;
+    fn todo_list(&mut self) -> Result<String>;
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct StartupDiagnostics {
+    registry_warning: Option<String>,
+    watcher_warning: Option<String>,
+}
+
+#[derive(Debug)]
+struct StartupResources<S, W> {
+    sock_path: PathBuf,
+    server: S,
+    watcher: Option<W>,
+    diagnostics: StartupDiagnostics,
+}
+
+trait StartupPlatform {
+    type Server;
+    type Watcher;
+
+    fn register_signal_handlers(
+        &self,
+        shutdown: &Arc<AtomicBool>,
+        wake_requested: &Arc<AtomicBool>,
+    ) -> Result<()>;
+    fn bind_socket_server(&self, sock_path: &Path) -> Result<Self::Server>;
+    fn register_registry(&self, dir: &Path, sock_path: &Path) -> Result<()>;
+    fn start_inbox_watcher(
+        &self,
+        inbox_path: &Path,
+        tx: mpsc::Sender<DaemonEvent>,
+    ) -> Result<Self::Watcher>;
+}
+
+struct FsSessionEffects<'a> {
+    dir: &'a Path,
+}
+
+impl<'a> FsSessionEffects<'a> {
+    fn new(dir: &'a Path) -> Self {
+        Self { dir }
+    }
+
+    fn todo_path(&self) -> PathBuf {
+        self.dir.join("todo.json")
+    }
+}
+
+impl SessionEffects for FsSessionEffects<'_> {
+    fn archive_inbox(&mut self, inbox_filenames: &[String]) -> Result<()> {
+        crate::message::archive_messages(self.dir, inbox_filenames)
+    }
+
+    fn write_reply(&mut self, text: &str, timestamp: NaiveDateTime) -> Result<()> {
+        let msg = crate::message::Message {
+            from: "agent".to_string(),
+            subject: "Reply".to_string(),
+            body: text.to_string(),
+            timestamp,
+            metadata: std::collections::BTreeMap::new(),
+        };
+        crate::message::write_message(self.dir, "outbox", &msg)?;
+        Ok(())
+    }
+
+    fn todo_add(&mut self, text: &str, at: &str) -> Result<u32> {
+        let todo_path = self.todo_path();
+        let mut list = crate::todo::TodoList::load(&todo_path)?;
+        let id = list.add(text.to_string(), at.to_string());
+        list.save(&todo_path)?;
+        Ok(id)
+    }
+
+    fn todo_done(&mut self, id: u32) -> Result<()> {
+        let todo_path = self.todo_path();
+        let mut list = crate::todo::TodoList::load(&todo_path)?;
+        list.done(id)?;
+        list.save(&todo_path)?;
+        Ok(())
+    }
+
+    fn todo_remove(&mut self, id: u32) -> Result<()> {
+        let todo_path = self.todo_path();
+        let mut list = crate::todo::TodoList::load(&todo_path)?;
+        list.remove(id)?;
+        list.save(&todo_path)?;
+        Ok(())
+    }
+
+    fn todo_list(&mut self) -> Result<String> {
+        let list = crate::todo::TodoList::load(&self.todo_path())?;
+        Ok(list.display())
+    }
+}
+
+struct SystemStartupPlatform;
+
+impl StartupPlatform for SystemStartupPlatform {
+    type Server = crate::socket::SocketServer;
+    type Watcher = InboxWatcher;
+
+    fn register_signal_handlers(
+        &self,
+        shutdown: &Arc<AtomicBool>,
+        wake_requested: &Arc<AtomicBool>,
+    ) -> Result<()> {
+        flag::register(SIGTERM, Arc::clone(shutdown))
+            .context("Failed to register SIGTERM handler")?;
+        flag::register(SIGINT, Arc::clone(shutdown))
+            .context("Failed to register SIGINT handler")?;
+        flag::register(SIGUSR1, Arc::clone(wake_requested))
+            .context("Failed to register SIGUSR1 handler")?;
+        Ok(())
+    }
+
+    fn bind_socket_server(&self, sock_path: &Path) -> Result<Self::Server> {
+        let server = crate::socket::SocketServer::bind(sock_path)?;
+        server.set_nonblocking(true)?;
+        Ok(server)
+    }
+
+    fn register_registry(&self, dir: &Path, sock_path: &Path) -> Result<()> {
+        crate::registry::register(dir, Some(sock_path))?;
+        Ok(())
+    }
+
+    fn start_inbox_watcher(
+        &self,
+        inbox_path: &Path,
+        tx: mpsc::Sender<DaemonEvent>,
+    ) -> Result<Self::Watcher> {
+        InboxWatcher::start(inbox_path, tx)
+    }
+}
+
+struct ProcessSessionRuntime<'a> {
+    server: &'a crate::socket::SocketServer,
+    child: &'a mut std::process::Child,
+    clock: Arc<dyn Clock>,
+    pending_responder: Option<crate::socket::Responder>,
+}
+
+impl<'a> ProcessSessionRuntime<'a> {
+    fn new(
+        server: &'a crate::socket::SocketServer,
+        child: &'a mut std::process::Child,
+        clock: Arc<dyn Clock>,
+    ) -> Self {
+        Self {
+            server,
+            child,
+            clock,
+            pending_responder: None,
+        }
+    }
+}
+
+impl SessionRuntime for ProcessSessionRuntime<'_> {
+    fn accept_request(
+        &mut self,
+        expected_instance_id: Option<&str>,
+    ) -> Result<Option<crate::socket::Request>> {
+        match self.server.accept_one(expected_instance_id) {
+            Ok(Some((request, responder))) => {
+                self.pending_responder = Some(responder);
+                Ok(Some(request))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => {
+                if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+                    if io_err.kind() == std::io::ErrorKind::WouldBlock {
+                        return Ok(None);
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+
+    fn respond(&mut self, ok: bool, message: String) -> Result<()> {
+        let responder = self
+            .pending_responder
+            .take()
+            .context("Missing pending session responder")?;
+        responder.respond(&crate::socket::Response { ok, message })?;
+        Ok(())
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<ChildExitStatus>> {
+        self.child.try_wait().map(|status| {
+            status.map(|status| ChildExitStatus {
+                code: status.code(),
+            })
+        })
+    }
+
+    fn terminate(&mut self) {
+        let pid = self.child.id();
+        terminate_child(self.child, pid, self.clock.as_ref());
+    }
+}
+
+fn resolve_hibernate_request(
+    complete: bool,
+    exit_code: u8,
+    summary: Option<&str>,
+    pending_fallback: &mut Option<FallbackAction>,
+) -> HibernateDecision {
+    let summary = summary.unwrap_or("(no summary)");
+    if exit_code != 0 {
+        return HibernateDecision {
+            outcome: SessionLoopOutcome::ValidationFailed { quick_exit: false },
+            response_message: "Failure recorded. Daemon will retry.",
+            log_event: format!("hibernate failed: exit={exit_code}, summary=\"{summary}\""),
+        };
+    }
+
+    if complete {
+        return HibernateDecision {
+            outcome: SessionLoopOutcome::PlanComplete,
+            response_message: "Plan complete. Shutting down.",
+            log_event: format!("hibernate: plan complete, exit={exit_code}, summary=\"{summary}\""),
+        };
+    }
+
+    HibernateDecision {
+        outcome: SessionLoopOutcome::Hibernate {
+            fallback: pending_fallback.take(),
+        },
+        response_message: "Hibernating.",
+        log_event: format!("hibernate: exit={exit_code}, summary=\"{summary}\""),
+    }
+}
+
+fn resolve_interrupted_session(
+    interruption: SessionInterruption,
+    hibernate_outcome: Option<SessionLoopOutcome>,
+) -> InterruptedSessionDecision {
+    match (interruption, hibernate_outcome) {
+        (SessionInterruption::Shutdown, Some(outcome)) => InterruptedSessionDecision {
+            outcome,
+            finish_reason: "daemon shutdown — using agent's hibernate outcome",
+        },
+        (SessionInterruption::Timeout, Some(outcome)) => InterruptedSessionDecision {
+            outcome,
+            finish_reason: "session timeout — using agent's hibernate outcome",
+        },
+        (SessionInterruption::Shutdown, None) => InterruptedSessionDecision {
+            outcome: SessionLoopOutcome::ValidationFailed { quick_exit: false },
+            finish_reason: "daemon shutdown — agent terminated",
+        },
+        (SessionInterruption::Timeout, None) => InterruptedSessionDecision {
+            outcome: SessionLoopOutcome::ValidationFailed { quick_exit: false },
+            finish_reason: "session timeout — agent killed",
+        },
+    }
+}
+
+fn resolve_child_exit(
+    hibernate_outcome: Option<SessionLoopOutcome>,
+    elapsed: Duration,
+) -> ChildExitDecision {
+    if let Some(outcome) = hibernate_outcome {
+        return ChildExitDecision {
+            outcome,
+            finish_reason: "session complete",
+            quick_exit: false,
+        };
+    }
+
+    let quick_exit = elapsed < Duration::from_secs(5);
+    ChildExitDecision {
+        outcome: SessionLoopOutcome::ValidationFailed { quick_exit },
+        finish_reason: "agent exited without hibernate",
+        quick_exit,
+    }
+}
+
 /// Gracefully terminate a child process: SIGTERM, wait 2s, SIGKILL if needed.
-fn terminate_child(child: &mut std::process::Child, pid: u32) {
+fn terminate_child(child: &mut std::process::Child, pid: u32, clock: &dyn Clock) {
     send_signal(pid, libc::SIGTERM);
-    std::thread::sleep(Duration::from_secs(2));
+    clock.sleep(Duration::from_secs(2));
     if child.try_wait().ok().flatten().is_none() {
         send_signal(pid, libc::SIGKILL);
     }
@@ -188,6 +611,26 @@ fn detect_delayed_wake(scheduled: NaiveDateTime, now: NaiveDateTime) -> Option<S
     }
 }
 
+fn pending_fallback_to_state(
+    pending: Option<&(NaiveDateTime, FallbackAction)>,
+) -> Option<PendingFallbackState> {
+    pending.map(|(deadline, action)| PendingFallbackState {
+        deadline: deadline.format(FALLBACK_TIME_FMT).to_string(),
+        action: action.clone(),
+    })
+}
+
+fn pending_fallback_from_state(
+    state: &CryoState,
+) -> Result<Option<(NaiveDateTime, FallbackAction)>> {
+    let Some(pending) = state.pending_fallback.as_ref() else {
+        return Ok(None);
+    };
+    let deadline = NaiveDateTime::parse_from_str(&pending.deadline, FALLBACK_TIME_FMT)
+        .with_context(|| format!("Invalid pending fallback deadline: {}", pending.deadline))?;
+    Ok(Some((deadline, pending.action.clone())))
+}
+
 /// The persistent daemon process.
 pub struct Daemon {
     dir: PathBuf,
@@ -195,10 +638,15 @@ pub struct Daemon {
     log_path: PathBuf,
     shutdown: Arc<AtomicBool>,
     wake_requested: Arc<AtomicBool>,
+    clock: Arc<dyn Clock>,
 }
 
 impl Daemon {
     pub fn new(dir: PathBuf) -> Self {
+        Self::with_clock(dir, Arc::new(SystemClock))
+    }
+
+    fn with_clock(dir: PathBuf, clock: Arc<dyn Clock>) -> Self {
         let state_path = dir.join("timer.json");
         let log_path = dir.join("cryo.log");
         Self {
@@ -207,19 +655,275 @@ impl Daemon {
             log_path,
             shutdown: Arc::new(AtomicBool::new(false)),
             wake_requested: Arc::new(AtomicBool::new(false)),
+            clock,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_clock(dir: PathBuf, clock: Arc<dyn Clock>) -> Self {
+        Self::with_clock(dir, clock)
+    }
+
+    fn sync_pending_fallback_state(
+        &self,
+        cryo_state: &mut CryoState,
+        pending: Option<&(NaiveDateTime, FallbackAction)>,
+    ) {
+        cryo_state.pending_fallback = pending_fallback_to_state(pending);
+    }
+
+    fn build_bootstrap_state(
+        &self,
+        cryo_state: &mut CryoState,
+        config: &CryoConfig,
+    ) -> DaemonBootstrapState {
+        let last_report = cryo_state
+            .last_report_time
+            .as_ref()
+            .and_then(|s| chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").ok());
+        let next_report_time = crate::report::compute_next_report_time(
+            &config.report_time,
+            config.report_interval,
+            last_report,
+        );
+
+        let next_wake = next_wake_from_todos(&self.dir);
+        let run_now = cryo_state.session_number == 0
+            || next_wake.is_some_and(|w| self.clock.local_now() >= w);
+
+        let inbox_path = self.dir.join("messages").join("inbox");
+        let watch_inbox_path = if config.watch_inbox && inbox_path.exists() {
+            Some(inbox_path)
+        } else {
+            None
+        };
+
+        let (pending_fallback, cleared_invalid_pending_fallback) =
+            match pending_fallback_from_state(cryo_state) {
+                Ok(pending) => (pending, false),
+                Err(e) => {
+                    eprintln!("Daemon: clearing invalid pending fallback state: {e}");
+                    cryo_state.pending_fallback = None;
+                    (None, true)
+                }
+            };
+
+        DaemonBootstrapState {
+            next_report_time,
+            next_wake,
+            run_now,
+            pending_fallback,
+            watch_inbox_path,
+            cleared_invalid_pending_fallback,
+        }
+    }
+
+    fn prepare_shutdown_state(
+        &self,
+        cryo_state: &mut CryoState,
+        pending: Option<&(NaiveDateTime, FallbackAction)>,
+    ) {
+        cryo_state.pid = None;
+        cryo_state.instance_id = None;
+        self.sync_pending_fallback_state(cryo_state, pending);
+    }
+
+    fn prepare_runtime_startup<P: StartupPlatform>(
+        &self,
+        platform: &P,
+        watch_inbox_path: Option<&Path>,
+        tx: mpsc::Sender<DaemonEvent>,
+    ) -> Result<StartupResources<P::Server, P::Watcher>> {
+        platform.register_signal_handlers(&self.shutdown, &self.wake_requested)?;
+
+        let sock_path = crate::socket::socket_path(&self.dir);
+        if let Some(parent) = sock_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let server = platform.bind_socket_server(&sock_path)?;
+
+        let registry_warning = platform
+            .register_registry(&self.dir, &sock_path)
+            .err()
+            .map(|e| e.to_string());
+
+        let (watcher, watcher_warning) = if let Some(inbox_path) = watch_inbox_path {
+            match platform.start_inbox_watcher(inbox_path, tx) {
+                Ok(watcher) => (Some(watcher), None),
+                Err(e) => (None, Some(e.to_string())),
+            }
+        } else {
+            (None, None)
+        };
+
+        Ok(StartupResources {
+            sock_path,
+            server,
+            watcher,
+            diagnostics: StartupDiagnostics {
+                registry_warning,
+                watcher_warning,
+            },
+        })
+    }
+
+    fn handle_idle_request(
+        &self,
+        request: crate::socket::Request,
+        responder: crate::socket::Responder,
+    ) -> Result<()> {
+        match request {
+            crate::socket::Request::Ping => {
+                let _ = responder.respond(&crate::socket::Response {
+                    ok: true,
+                    message: "pong".into(),
+                });
+            }
+            crate::socket::Request::TodoAdd { text, at } => {
+                let todo_path = self.dir.join("todo.json");
+                match crate::todo::TodoList::load(&todo_path) {
+                    Ok(mut list) => {
+                        let id = list.add(text, at);
+                        let response = match list.save(&todo_path) {
+                            Ok(()) => crate::socket::Response {
+                                ok: true,
+                                message: format!("Added todo #{id}"),
+                            },
+                            Err(e) => crate::socket::Response {
+                                ok: false,
+                                message: format!("Failed to save todo: {e}"),
+                            },
+                        };
+                        let _ = responder.respond(&response);
+                    }
+                    Err(e) => {
+                        let _ = responder.respond(&crate::socket::Response {
+                            ok: false,
+                            message: format!("Failed to load todo list: {e}"),
+                        });
+                    }
+                }
+            }
+            crate::socket::Request::TodoDone { id } => {
+                let todo_path = self.dir.join("todo.json");
+                match crate::todo::TodoList::load(&todo_path) {
+                    Ok(mut list) => {
+                        let response = match list.done(id) {
+                            Ok(()) => match list.save(&todo_path) {
+                                Ok(()) => crate::socket::Response {
+                                    ok: true,
+                                    message: format!("Marked todo #{id} as done"),
+                                },
+                                Err(e) => crate::socket::Response {
+                                    ok: false,
+                                    message: format!("Failed to save todo: {e}"),
+                                },
+                            },
+                            Err(e) => crate::socket::Response {
+                                ok: false,
+                                message: format!("{e}"),
+                            },
+                        };
+                        let _ = responder.respond(&response);
+                    }
+                    Err(e) => {
+                        let _ = responder.respond(&crate::socket::Response {
+                            ok: false,
+                            message: format!("Failed to load todo list: {e}"),
+                        });
+                    }
+                }
+            }
+            crate::socket::Request::TodoRemove { id } => {
+                let todo_path = self.dir.join("todo.json");
+                match crate::todo::TodoList::load(&todo_path) {
+                    Ok(mut list) => {
+                        let response = match list.remove(id) {
+                            Ok(()) => match list.save(&todo_path) {
+                                Ok(()) => crate::socket::Response {
+                                    ok: true,
+                                    message: format!("Removed todo #{id}"),
+                                },
+                                Err(e) => crate::socket::Response {
+                                    ok: false,
+                                    message: format!("Failed to save todo: {e}"),
+                                },
+                            },
+                            Err(e) => crate::socket::Response {
+                                ok: false,
+                                message: format!("{e}"),
+                            },
+                        };
+                        let _ = responder.respond(&response);
+                    }
+                    Err(e) => {
+                        let _ = responder.respond(&crate::socket::Response {
+                            ok: false,
+                            message: format!("Failed to load todo list: {e}"),
+                        });
+                    }
+                }
+            }
+            crate::socket::Request::TodoList => {
+                let todo_path = self.dir.join("todo.json");
+                match crate::todo::TodoList::load(&todo_path) {
+                    Ok(list) => {
+                        let _ = responder.respond(&crate::socket::Response {
+                            ok: true,
+                            message: list.display(),
+                        });
+                    }
+                    Err(e) => {
+                        let _ = responder.respond(&crate::socket::Response {
+                            ok: false,
+                            message: format!("Failed to load todo list: {e}"),
+                        });
+                    }
+                }
+            }
+            crate::socket::Request::Note { .. }
+            | crate::socket::Request::Hibernate { .. }
+            | crate::socket::Request::Alert { .. }
+            | crate::socket::Request::Reply { .. } => {
+                let _ = responder.respond(&crate::socket::Response {
+                    ok: false,
+                    message:
+                        "No active session. This command is only valid while the agent is running."
+                            .into(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn service_idle_socket_requests(
+        &self,
+        server: &crate::socket::SocketServer,
+        expected_instance_id: Option<&str>,
+    ) {
+        loop {
+            match server.accept_one(expected_instance_id) {
+                Ok(Some((request, responder))) => {
+                    if let Err(e) = self.handle_idle_request(request, responder) {
+                        eprintln!("Daemon: idle socket request failed: {e}");
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+                        if io_err.kind() == std::io::ErrorKind::WouldBlock {
+                            break;
+                        }
+                    }
+                    eprintln!("Daemon: socket accept error: {e}");
+                    break;
+                }
+            }
         }
     }
 
     /// Run the daemon event loop. Blocks until SIGTERM or plan completion.
     pub fn run(&self) -> Result<()> {
-        // Register signal handlers
-        flag::register(SIGTERM, Arc::clone(&self.shutdown))
-            .context("Failed to register SIGTERM handler")?;
-        flag::register(SIGINT, Arc::clone(&self.shutdown))
-            .context("Failed to register SIGINT handler")?;
-        flag::register(SIGUSR1, Arc::clone(&self.wake_requested))
-            .context("Failed to register SIGUSR1 handler")?;
-
         let mut cryo_state =
             state::load_state(&self.state_path)?.context("No cryochamber state found")?;
 
@@ -235,50 +939,52 @@ impl Daemon {
         let mut config =
             crate::config::load_config(&crate::config::config_path(&self.dir))?.unwrap_or_default();
         config.apply_overrides(&cryo_state);
+        let bootstrap = self.build_bootstrap_state(&mut cryo_state, &config);
 
         // Save PID so other commands can detect the running daemon
         cryo_state.pid = Some(std::process::id());
+        cryo_state.instance_id = Some(state::new_instance_id());
         state::save_state(&self.state_path, &cryo_state)?;
 
-        // Create .cryo/ directory and bind socket server
-        let sock_path = crate::socket::socket_path(&self.dir);
-        if let Some(parent) = sock_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let server = crate::socket::SocketServer::bind(&sock_path)?;
-        server.set_nonblocking(true)?;
-        eprintln!("Daemon: socket listening at {}", sock_path.display());
-
-        // Register in global daemon registry (with socket path)
-        if let Err(e) = crate::registry::register(&self.dir, Some(&sock_path)) {
-            eprintln!("Daemon: failed to register in ~/.cryo/daemons: {e}");
-        }
-
-        // Set up inbox watcher
         let (tx, rx) = mpsc::channel();
-        let inbox_path = self.dir.join("messages").join("inbox");
-        let _watcher = if config.watch_inbox && inbox_path.exists() {
-            match InboxWatcher::start(&inbox_path, tx.clone()) {
-                Ok(w) => {
-                    eprintln!("Daemon: watching messages/inbox/ for new messages");
-                    Some(w)
+        let startup = match self.prepare_runtime_startup(
+            &SystemStartupPlatform,
+            bootstrap.watch_inbox_path.as_deref(),
+            tx.clone(),
+        ) {
+            Ok(startup) => startup,
+            Err(e) => {
+                self.prepare_shutdown_state(&mut cryo_state, bootstrap.pending_fallback.as_ref());
+                if let Err(save_err) = state::save_state(&self.state_path, &cryo_state) {
+                    eprintln!("Daemon: failed to restore state after startup failure: {save_err}");
                 }
-                Err(e) => {
-                    eprintln!("Daemon: failed to start inbox watcher: {e}");
-                    None
-                }
+                return Err(e);
             }
-        } else {
-            None
         };
+
+        let sock_path = startup.sock_path;
+        let server = startup.server;
+        eprintln!("Daemon: socket listening at {}", sock_path.display());
+        if let Some(warning) = startup.diagnostics.registry_warning {
+            eprintln!("Daemon: failed to register in ~/.cryo/daemons: {warning}");
+        }
+
+        let watcher_started = startup.watcher.is_some();
+        if let Some(warning) = startup.diagnostics.watcher_warning {
+            eprintln!("Daemon: failed to start inbox watcher: {warning}");
+        } else if watcher_started {
+            eprintln!("Daemon: watching messages/inbox/ for new messages");
+        }
+        let _watcher = startup.watcher;
 
         // Spawn a thread that forwards signals to the event channel,
         // so recv_timeout() unblocks immediately on SIGTERM/SIGINT/SIGUSR1.
         let shutdown_flag = Arc::clone(&self.shutdown);
         let wake_flag = Arc::clone(&self.wake_requested);
         let signal_tx = tx;
+        let signal_clock = Arc::clone(&self.clock);
         std::thread::spawn(move || loop {
-            std::thread::sleep(Duration::from_millis(250));
+            signal_clock.sleep(Duration::from_millis(250));
             if shutdown_flag.load(Ordering::Relaxed) {
                 let _ = signal_tx.send(DaemonEvent::Shutdown);
                 break;
@@ -288,16 +994,7 @@ impl Daemon {
             }
         });
 
-        // Compute next report time
-        let last_report = cryo_state
-            .last_report_time
-            .as_ref()
-            .and_then(|s| chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").ok());
-        let mut next_report_time = crate::report::compute_next_report_time(
-            &config.report_time,
-            config.report_interval,
-            last_report,
-        );
+        let mut next_report_time = bootstrap.next_report_time;
         if config.report_interval > 0 && next_report_time.is_none() {
             eprintln!(
                 "Daemon: warning: report_interval={} but report_time='{}' is invalid (expected HH:MM)",
@@ -310,12 +1007,10 @@ impl Daemon {
 
         let provider_count = config.providers.len();
         let mut retry = RetryState::new(config.max_retries, provider_count);
-        // Derive next wake from TODO list.
-        let mut next_wake = next_wake_from_todos(&self.dir);
-        let mut run_now = cryo_state.session_number == 0
-            || next_wake.is_some_and(|w| Local::now().naive_local() >= w);
+        let mut next_wake = bootstrap.next_wake;
+        let mut run_now = bootstrap.run_now;
         let mut inbox_wake = false;
-        let mut pending_fallback: Option<(NaiveDateTime, FallbackAction)> = None;
+        let mut pending_fallback = bootstrap.pending_fallback;
 
         loop {
             if self.shutdown.load(Ordering::Relaxed) {
@@ -336,20 +1031,23 @@ impl Daemon {
                     None
                 } else {
                     next_wake.and_then(|wake| {
-                    let now = Local::now().naive_local();
-                    detect_delayed_wake(wake, now).map(|delay_str| {
-                        // Cancel premature fallback — the session is about to run
-                        pending_fallback = None;
-                        format!(
-                            "DELAYED WAKE: This session was scheduled for {} but is running {} late \
-                             (the host machine was likely suspended or powered off). \
-                             Check whether time-sensitive tasks need adjustment.",
-                            wake.format(WAKE_TIME_FMT),
-                            delay_str,
-                        )
+                        let now = self.clock.local_now();
+                        detect_delayed_wake(wake, now).map(|delay_str| {
+                            format!(
+                                "DELAYED WAKE: This session was scheduled for {} but is running {} late \
+                                 (the host machine was likely suspended or powered off). \
+                                 Check whether time-sensitive tasks need adjustment.",
+                                wake.format(WAKE_TIME_FMT),
+                                delay_str,
+                            )
+                        })
                     })
-                })
                 };
+                if delayed_wake.is_some() && pending_fallback.is_some() {
+                    pending_fallback = None;
+                    self.sync_pending_fallback_state(&mut cryo_state, pending_fallback.as_ref());
+                    let _ = state::save_state(&self.state_path, &cryo_state);
+                }
                 cryo_state.session_number += 1;
                 if !config.providers.is_empty() {
                     cryo_state.provider_index = Some(retry.provider_index);
@@ -376,17 +1074,26 @@ impl Daemon {
                         match outcome {
                             SessionLoopOutcome::PlanComplete => {
                                 retry.reset();
-                                drop(pending_fallback);
+                                pending_fallback = None;
+                                self.sync_pending_fallback_state(
+                                    &mut cryo_state,
+                                    pending_fallback.as_ref(),
+                                );
+                                let _ = state::save_state(&self.state_path, &cryo_state);
                                 eprintln!("Daemon: plan complete. Shutting down.");
                                 break;
                             }
                             SessionLoopOutcome::Hibernate { fallback } => {
                                 retry.reset();
                                 next_wake = next_wake_from_todos(&self.dir);
-                                let _ = state::save_state(&self.state_path, &cryo_state);
                                 pending_fallback = next_wake
                                     .map(|w| (w + chrono::Duration::hours(1), fallback))
                                     .and_then(|(deadline, fb)| fb.map(|f| (deadline, f)));
+                                self.sync_pending_fallback_state(
+                                    &mut cryo_state,
+                                    pending_fallback.as_ref(),
+                                );
+                                let _ = state::save_state(&self.state_path, &cryo_state);
                                 if let Some(w) = next_wake {
                                     eprintln!(
                                         "Daemon: next wake at {}",
@@ -464,37 +1171,41 @@ impl Daemon {
                 }
             }
 
+            let expected_instance_id = cryo_state.instance_id.as_deref();
+            self.service_idle_socket_requests(&server, expected_instance_id);
+
             // Check fallback only when idle (not about to run a session)
-            self.check_fallback(&mut pending_fallback, &config.fallback_alert);
+            self.check_fallback(
+                &mut cryo_state,
+                &mut pending_fallback,
+                &config.fallback_alert,
+            );
 
             // Check if periodic report is due
             if let Some(report_time) = next_report_time {
-                if Local::now().naive_local() >= report_time {
+                if self.clock.local_now() >= report_time {
                     self.send_periodic_report(&config, &mut cryo_state, &mut next_report_time);
                 }
             }
 
             // Wait for next event
             let timeout =
-                compute_sleep_timeout(next_wake, next_report_time, Local::now().naive_local());
+                compute_sleep_timeout(next_wake, next_report_time, self.clock.local_now())
+                    .min(Duration::from_millis(250));
 
-            match rx.recv_timeout(timeout) {
-                Ok(DaemonEvent::InboxChanged) => {
-                    // Drain any additional queued InboxChanged events to coalesce
-                    // multiple file-system notifications into a single session.
-                    while let Ok(DaemonEvent::InboxChanged) = rx.try_recv() {}
+            match wait_for_idle_event(&rx, timeout, next_wake.is_some()) {
+                IdleWaitOutcome::WakeFromInbox => {
                     eprintln!("Daemon: inbox changed, waking up");
                     run_now = true;
                     inbox_wake = true;
                 }
-                Ok(DaemonEvent::Shutdown) => break,
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    if next_wake.is_some() {
-                        eprintln!("Daemon: scheduled wake time reached");
-                        run_now = true;
-                    }
+                IdleWaitOutcome::WakeFromSchedule => {
+                    eprintln!("Daemon: scheduled wake time reached");
+                    run_now = true;
                 }
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                IdleWaitOutcome::Shutdown => break,
+                IdleWaitOutcome::StayIdle => {}
+                IdleWaitOutcome::Disconnected => {
                     eprintln!("Daemon: event channel disconnected");
                     break;
                 }
@@ -502,7 +1213,7 @@ impl Daemon {
         }
 
         // Cleanup: always unregister and remove socket, even if state save fails
-        cryo_state.pid = None;
+        self.prepare_shutdown_state(&mut cryo_state, pending_fallback.as_ref());
         if let Err(e) = state::save_state(&self.state_path, &cryo_state) {
             eprintln!("Daemon: failed to save final state: {e}");
         }
@@ -585,333 +1296,248 @@ impl Daemon {
         let mut child =
             crate::agent::spawn_agent(&agent_cmd, &prompt, Some(agent_log_file), provider_env)?;
         let child_pid = child.id();
-        let spawn_time = std::time::Instant::now();
+        let spawn_time = self.clock.monotonic_now();
         logger.log_event(&format!("agent started (pid {child_pid})"))?;
         if let Some(name) = provider_name {
             logger.log_event(&format!("provider: {name}"))?;
         }
 
-        // Poll loop: wait for socket commands + agent exit
-        let deadline = if timeout_secs > 0 {
-            Some(std::time::Instant::now() + Duration::from_secs(timeout_secs))
+        let mut runtime = ProcessSessionRuntime::new(server, &mut child, Arc::clone(&self.clock));
+        let mut effects = FsSessionEffects::new(&self.dir);
+        let context = ActiveSessionContext {
+            cryo_state,
+            timeout_secs,
+            spawn_time,
+            inbox_filenames: &inbox_filenames,
+        };
+        self.drive_active_session(&mut runtime, &mut effects, context, logger)
+    }
+
+    fn handle_active_request(
+        &self,
+        request: crate::socket::Request,
+        runtime: &mut impl SessionRuntime,
+        effects: &mut impl SessionEffects,
+        logger: &mut crate::log::EventLogger,
+        pending_fallback: &mut Option<FallbackAction>,
+        hibernate_outcome: &mut Option<SessionLoopOutcome>,
+    ) -> Result<()> {
+        match request {
+            crate::socket::Request::Ping => {
+                let _ = runtime.respond(true, "pong".into());
+            }
+            crate::socket::Request::Note { text } => {
+                logger.log_event(&format!("note: \"{text}\""))?;
+                let _ = runtime.respond(true, "Note recorded".into());
+            }
+            crate::socket::Request::Hibernate {
+                complete,
+                exit_code,
+                summary,
+            } => {
+                let decision = resolve_hibernate_request(
+                    complete,
+                    exit_code,
+                    summary.as_deref(),
+                    pending_fallback,
+                );
+                logger.log_event(&decision.log_event)?;
+                *hibernate_outcome = Some(decision.outcome);
+                let _ = runtime.respond(true, decision.response_message.into());
+            }
+            crate::socket::Request::Alert {
+                action,
+                target,
+                message,
+            } => {
+                logger.log_event(&format!("alert: {action} -> {target}"))?;
+                *pending_fallback = Some(FallbackAction {
+                    action,
+                    target,
+                    message,
+                });
+                let _ = runtime.respond(true, "Alert registered".into());
+            }
+            crate::socket::Request::Reply { text } => {
+                match effects.write_reply(&text, self.clock.local_now()) {
+                    Ok(()) => {
+                        logger.log_event(&format!("reply: \"{text}\""))?;
+                        let _ = runtime.respond(true, "Reply sent".into());
+                    }
+                    Err(e) => {
+                        logger.log_event(&format!("reply failed: {e}"))?;
+                        let _ = runtime.respond(false, format!("Failed to write reply: {e}"));
+                    }
+                }
+            }
+            crate::socket::Request::TodoAdd { text, at } => match effects.todo_add(&text, &at) {
+                Ok(id) => {
+                    logger.log_event(&format!("todo add: #{id} \"{text}\" at {at}"))?;
+                    let _ = runtime.respond(true, format!("Added todo #{id}"));
+                }
+                Err(e) => {
+                    let _ = runtime.respond(false, format!("Failed to add todo: {e}"));
+                }
+            },
+            crate::socket::Request::TodoDone { id } => match effects.todo_done(id) {
+                Ok(()) => {
+                    logger.log_event(&format!("todo done: #{id}"))?;
+                    let _ = runtime.respond(true, format!("Marked todo #{id} as done"));
+                }
+                Err(e) => {
+                    let _ = runtime.respond(false, format!("{e}"));
+                }
+            },
+            crate::socket::Request::TodoRemove { id } => match effects.todo_remove(id) {
+                Ok(()) => {
+                    logger.log_event(&format!("todo remove: #{id}"))?;
+                    let _ = runtime.respond(true, format!("Removed todo #{id}"));
+                }
+                Err(e) => {
+                    let _ = runtime.respond(false, format!("{e}"));
+                }
+            },
+            crate::socket::Request::TodoList => match effects.todo_list() {
+                Ok(display) => {
+                    let _ = runtime.respond(true, display);
+                }
+                Err(e) => {
+                    let _ = runtime.respond(false, format!("Failed to load todo list: {e}"));
+                }
+            },
+        }
+        Ok(())
+    }
+
+    fn drive_active_session(
+        &self,
+        runtime: &mut impl SessionRuntime,
+        effects: &mut impl SessionEffects,
+        context: ActiveSessionContext<'_>,
+        mut logger: crate::log::EventLogger,
+    ) -> Result<SessionLoopOutcome> {
+        let deadline = if context.timeout_secs > 0 {
+            Some(context.spawn_time + Duration::from_secs(context.timeout_secs))
         } else {
             None
         };
 
         let mut hibernate_outcome: Option<SessionLoopOutcome> = None;
         let mut pending_fallback: Option<FallbackAction> = None;
+        let expected_instance_id = context.cryo_state.instance_id.as_deref();
 
         loop {
-            // Check shutdown
             if self.shutdown.load(Ordering::Relaxed) {
-                terminate_child(&mut child, child_pid);
-                if !inbox_filenames.is_empty() {
-                    let _ = crate::message::archive_messages(&self.dir, &inbox_filenames);
+                runtime.terminate();
+                if !context.inbox_filenames.is_empty() {
+                    let _ = effects.archive_inbox(context.inbox_filenames);
                 }
-                if let Some(outcome) = hibernate_outcome {
-                    logger.finish("daemon shutdown — using agent's hibernate outcome")?;
-                    return Ok(outcome);
-                }
-                logger.finish("daemon shutdown — agent terminated")?;
-                return Ok(SessionLoopOutcome::ValidationFailed { quick_exit: false });
+                let decision = resolve_interrupted_session(
+                    SessionInterruption::Shutdown,
+                    hibernate_outcome.take(),
+                );
+                logger.finish(decision.finish_reason)?;
+                return Ok(decision.outcome);
             }
 
-            // Check timeout
             if let Some(d) = deadline {
-                if std::time::Instant::now() >= d {
-                    eprintln!("Daemon: session timeout ({timeout_secs}s) — killing agent");
-                    terminate_child(&mut child, child_pid);
-                    if !inbox_filenames.is_empty() {
-                        let _ = crate::message::archive_messages(&self.dir, &inbox_filenames);
+                if self.clock.monotonic_now() >= d {
+                    eprintln!(
+                        "Daemon: session timeout ({}s) — killing agent",
+                        context.timeout_secs
+                    );
+                    runtime.terminate();
+                    if !context.inbox_filenames.is_empty() {
+                        let _ = effects.archive_inbox(context.inbox_filenames);
                     }
-                    if let Some(outcome) = hibernate_outcome {
-                        logger.finish("session timeout — using agent's hibernate outcome")?;
-                        return Ok(outcome);
-                    }
-                    logger.finish("session timeout — agent killed")?;
-                    return Ok(SessionLoopOutcome::ValidationFailed { quick_exit: false });
+                    let decision = resolve_interrupted_session(
+                        SessionInterruption::Timeout,
+                        hibernate_outcome.take(),
+                    );
+                    logger.finish(decision.finish_reason)?;
+                    return Ok(decision.outcome);
                 }
             }
 
-            // Try accept a socket connection (non-blocking)
-            match server.accept_one() {
-                Ok(Some((request, responder))) => {
-                    match request {
-                        crate::socket::Request::Note { text } => {
-                            logger.log_event(&format!("note: \"{text}\""))?;
-                            let _ = responder.respond(&crate::socket::Response {
-                                ok: true,
-                                message: "Note recorded".into(),
-                            });
-                        }
-                        crate::socket::Request::Hibernate {
-                            complete,
-                            exit_code,
-                            summary,
-                        } => {
-                            let summary_str = summary.as_deref().unwrap_or("(no summary)");
-                            if complete {
-                                logger.log_event(&format!(
-                                    "hibernate: plan complete, exit={exit_code}, summary=\"{summary_str}\""
-                                ))?;
-                                hibernate_outcome = Some(SessionLoopOutcome::PlanComplete);
-                            } else {
-                                logger.log_event(&format!(
-                                    "hibernate: exit={exit_code}, summary=\"{summary_str}\""
-                                ))?;
-                                hibernate_outcome = Some(SessionLoopOutcome::Hibernate {
-                                    fallback: pending_fallback.take(),
-                                });
-                            }
-                            let _ = responder.respond(&crate::socket::Response {
-                                ok: true,
-                                message: if complete {
-                                    "Plan complete. Shutting down.".into()
-                                } else {
-                                    "Hibernating.".into()
-                                },
-                            });
-                        }
-                        crate::socket::Request::Alert {
-                            action,
-                            target,
-                            message,
-                        } => {
-                            logger.log_event(&format!("alert: {action} -> {target}"))?;
-                            pending_fallback = Some(FallbackAction {
-                                action,
-                                target,
-                                message,
-                            });
-                            let _ = responder.respond(&crate::socket::Response {
-                                ok: true,
-                                message: "Alert registered".into(),
-                            });
-                        }
-                        crate::socket::Request::Reply { text } => {
-                            // Write reply to outbox
-                            let msg = crate::message::Message {
-                                from: "agent".to_string(),
-                                subject: "Reply".to_string(),
-                                body: text.clone(),
-                                timestamp: chrono::Local::now().naive_local(),
-                                metadata: std::collections::BTreeMap::new(),
-                            };
-                            match crate::message::write_message(&self.dir, "outbox", &msg) {
-                                Ok(_) => {
-                                    logger.log_event(&format!("reply: \"{text}\""))?;
-                                    let _ = responder.respond(&crate::socket::Response {
-                                        ok: true,
-                                        message: "Reply sent".into(),
-                                    });
-                                }
-                                Err(e) => {
-                                    logger.log_event(&format!("reply failed: {e}"))?;
-                                    let _ = responder.respond(&crate::socket::Response {
-                                        ok: false,
-                                        message: format!("Failed to write reply: {e}"),
-                                    });
-                                }
-                            }
-                        }
-                        crate::socket::Request::TodoAdd { text, at } => {
-                            let todo_path = self.dir.join("todo.json");
-                            match crate::todo::TodoList::load(&todo_path) {
-                                Ok(mut list) => {
-                                    let id = list.add(text.clone(), at.clone());
-                                    match list.save(&todo_path) {
-                                        Ok(()) => {
-                                            logger.log_event(&format!(
-                                                "todo add: #{id} \"{text}\" at {at}"
-                                            ))?;
-                                            let _ = responder.respond(&crate::socket::Response {
-                                                ok: true,
-                                                message: format!("Added todo #{id}"),
-                                            });
-                                        }
-                                        Err(e) => {
-                                            let _ = responder.respond(&crate::socket::Response {
-                                                ok: false,
-                                                message: format!("Failed to save todo: {e}"),
-                                            });
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    let _ = responder.respond(&crate::socket::Response {
-                                        ok: false,
-                                        message: format!("Failed to load todo list: {e}"),
-                                    });
-                                }
-                            }
-                        }
-                        crate::socket::Request::TodoDone { id } => {
-                            let todo_path = self.dir.join("todo.json");
-                            match crate::todo::TodoList::load(&todo_path) {
-                                Ok(mut list) => match list.done(id) {
-                                    Ok(()) => match list.save(&todo_path) {
-                                        Ok(()) => {
-                                            logger.log_event(&format!("todo done: #{id}"))?;
-                                            let _ = responder.respond(&crate::socket::Response {
-                                                ok: true,
-                                                message: format!("Marked todo #{id} as done"),
-                                            });
-                                        }
-                                        Err(e) => {
-                                            let _ = responder.respond(&crate::socket::Response {
-                                                ok: false,
-                                                message: format!("Failed to save todo: {e}"),
-                                            });
-                                        }
-                                    },
-                                    Err(e) => {
-                                        let _ = responder.respond(&crate::socket::Response {
-                                            ok: false,
-                                            message: format!("{e}"),
-                                        });
-                                    }
-                                },
-                                Err(e) => {
-                                    let _ = responder.respond(&crate::socket::Response {
-                                        ok: false,
-                                        message: format!("Failed to load todo list: {e}"),
-                                    });
-                                }
-                            }
-                        }
-                        crate::socket::Request::TodoRemove { id } => {
-                            let todo_path = self.dir.join("todo.json");
-                            match crate::todo::TodoList::load(&todo_path) {
-                                Ok(mut list) => match list.remove(id) {
-                                    Ok(()) => match list.save(&todo_path) {
-                                        Ok(()) => {
-                                            logger.log_event(&format!("todo remove: #{id}"))?;
-                                            let _ = responder.respond(&crate::socket::Response {
-                                                ok: true,
-                                                message: format!("Removed todo #{id}"),
-                                            });
-                                        }
-                                        Err(e) => {
-                                            let _ = responder.respond(&crate::socket::Response {
-                                                ok: false,
-                                                message: format!("Failed to save todo: {e}"),
-                                            });
-                                        }
-                                    },
-                                    Err(e) => {
-                                        let _ = responder.respond(&crate::socket::Response {
-                                            ok: false,
-                                            message: format!("{e}"),
-                                        });
-                                    }
-                                },
-                                Err(e) => {
-                                    let _ = responder.respond(&crate::socket::Response {
-                                        ok: false,
-                                        message: format!("Failed to load todo list: {e}"),
-                                    });
-                                }
-                            }
-                        }
-                        crate::socket::Request::TodoList => {
-                            let todo_path = self.dir.join("todo.json");
-                            match crate::todo::TodoList::load(&todo_path) {
-                                Ok(list) => {
-                                    let _ = responder.respond(&crate::socket::Response {
-                                        ok: true,
-                                        message: list.display(),
-                                    });
-                                }
-                                Err(e) => {
-                                    let _ = responder.respond(&crate::socket::Response {
-                                        ok: false,
-                                        message: format!("Failed to load todo list: {e}"),
-                                    });
-                                }
-                            }
-                        }
-                    }
-                }
-                Ok(None) => {} // empty connection, ignore
+            match runtime.accept_request(expected_instance_id) {
+                Ok(Some(request)) => self.handle_active_request(
+                    request,
+                    runtime,
+                    effects,
+                    &mut logger,
+                    &mut pending_fallback,
+                    &mut hibernate_outcome,
+                )?,
+                Ok(None) => {}
                 Err(e) => {
-                    // WouldBlock is expected in non-blocking mode
-                    if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
-                        if io_err.kind() != std::io::ErrorKind::WouldBlock {
-                            eprintln!("Daemon: socket accept error: {e}");
-                        }
-                    }
+                    eprintln!("Daemon: socket accept error: {e}");
                 }
             }
 
-            // Check if agent has exited
-            match child.try_wait() {
+            match runtime.try_wait() {
                 Ok(Some(status)) => {
-                    let code = status.code();
-                    let elapsed = spawn_time.elapsed();
+                    let elapsed = self
+                        .clock
+                        .monotonic_now()
+                        .saturating_duration_since(context.spawn_time);
                     logger.log_event(&format!(
                         "agent exited (code {})",
-                        code.map(|c| c.to_string())
+                        status
+                            .code
+                            .map(|c| c.to_string())
                             .unwrap_or_else(|| "signal".into())
                     ))?;
 
-                    // Archive inbox messages now that agent has finished
-                    if !inbox_filenames.is_empty() {
-                        crate::message::archive_messages(&self.dir, &inbox_filenames)?;
+                    if !context.inbox_filenames.is_empty() {
+                        effects.archive_inbox(context.inbox_filenames)?;
                     }
 
-                    if let Some(outcome) = hibernate_outcome {
-                        logger.finish("session complete")?;
-                        return Ok(outcome);
-                    } else {
-                        // Quick-exit detection: agent exited fast without hibernating
-                        if elapsed < Duration::from_secs(5) {
-                            let elapsed_s = format!("{:.1}s", elapsed.as_secs_f32());
-                            eprintln!(
-                                "Daemon: agent exited in {elapsed_s} without hibernating — possible causes:\n  \
-                                 - Missing or invalid API key\n  \
-                                 - Agent command misconfigured (try running it manually)\n  \
-                                 - Check cryo-agent.log for details"
-                            );
-                            logger.log_event(&format!(
-                                "quick exit detected ({elapsed_s} without hibernate)"
-                            ))?;
-                        }
-                        // Agent exited without calling hibernate — treat as crash
-                        logger.finish("agent exited without hibernate")?;
-                        return Ok(SessionLoopOutcome::ValidationFailed {
-                            quick_exit: elapsed < Duration::from_secs(5),
-                        });
+                    let decision = resolve_child_exit(hibernate_outcome.take(), elapsed);
+                    if decision.quick_exit {
+                        let elapsed_s = format!("{:.1}s", elapsed.as_secs_f32());
+                        eprintln!(
+                            "Daemon: agent exited in {elapsed_s} without hibernating — possible causes:\n  \
+                             - Missing or invalid API key\n  \
+                             - Agent command misconfigured (try running it manually)\n  \
+                             - Check cryo-agent.log for details"
+                        );
+                        logger.log_event(&format!(
+                            "quick exit detected ({elapsed_s} without hibernate)"
+                        ))?;
                     }
+                    logger.finish(decision.finish_reason)?;
+                    return Ok(decision.outcome);
                 }
-                Ok(None) => {} // still running
+                Ok(None) => {}
                 Err(e) => {
                     logger.finish(&format!("error checking agent: {e}"))?;
                     return Err(e.into());
                 }
             }
 
-            // If we got a hibernate command but agent hasn't exited yet,
-            // give it a moment then continue polling
             if hibernate_outcome.is_some() {
-                // Agent sent hibernate but hasn't exited yet — wait a bit
-                // The agent should exit shortly after calling cryo hibernate
-                std::thread::sleep(Duration::from_millis(100));
+                self.clock.sleep(Duration::from_millis(100));
                 continue;
             }
 
-            std::thread::sleep(Duration::from_millis(100));
+            self.clock.sleep(Duration::from_millis(100));
         }
     }
 
     /// Execute a pending fallback if its deadline has passed.
     fn check_fallback(
         &self,
+        cryo_state: &mut CryoState,
         pending: &mut Option<(NaiveDateTime, FallbackAction)>,
         alert_method: &str,
     ) {
         if let Some((deadline, _)) = pending.as_ref() {
-            if Local::now().naive_local() > *deadline {
+            if self.clock.local_now() > *deadline {
                 let (_, fb) = pending.take().unwrap();
+                self.sync_pending_fallback_state(cryo_state, pending.as_ref());
+                if let Err(e) = state::save_state(&self.state_path, cryo_state) {
+                    eprintln!("Daemon: failed to clear pending fallback state: {e}");
+                }
                 eprintln!("Daemon: fallback deadline passed, executing fallback action");
                 if let Err(e) = fb.execute(&self.dir, alert_method) {
                     eprintln!("Daemon: fallback execution failed: {e}");
@@ -989,7 +1615,7 @@ impl Daemon {
         }
 
         // Update state and advance timer
-        let now = Local::now().naive_local();
+        let now = self.clock.local_now();
         let previous_last_report_time = cryo_state.last_report_time.clone();
         cryo_state.last_report_time = Some(now.format("%Y-%m-%dT%H:%M:%S").to_string());
         if let Err(e) = state::save_state(&self.state_path, cryo_state) {
@@ -1017,7 +1643,7 @@ impl Daemon {
                 return true;
             }
             let sleep_time = remaining.min(step);
-            std::thread::sleep(sleep_time);
+            self.clock.sleep(sleep_time);
             remaining = remaining.saturating_sub(sleep_time);
         }
         false
@@ -1027,6 +1653,352 @@ impl Daemon {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    struct TestClockState {
+        now: NaiveDateTime,
+        elapsed: Duration,
+        sleeps: Vec<Duration>,
+    }
+
+    struct TestClock {
+        origin: std::time::Instant,
+        state: Mutex<TestClockState>,
+    }
+
+    impl TestClock {
+        fn new(now: NaiveDateTime) -> Self {
+            Self {
+                origin: std::time::Instant::now(),
+                state: Mutex::new(TestClockState {
+                    now,
+                    elapsed: Duration::ZERO,
+                    sleeps: Vec::new(),
+                }),
+            }
+        }
+
+        fn advance(&self, duration: Duration) {
+            let mut state = self.state.lock().unwrap();
+            state.now += chrono::Duration::from_std(duration).unwrap();
+            state.elapsed += duration;
+        }
+
+        fn sleeps(&self) -> Vec<Duration> {
+            self.state.lock().unwrap().sleeps.clone()
+        }
+    }
+
+    impl Clock for TestClock {
+        fn local_now(&self) -> NaiveDateTime {
+            self.state.lock().unwrap().now
+        }
+
+        fn monotonic_now(&self) -> std::time::Instant {
+            let state = self.state.lock().unwrap();
+            self.origin + state.elapsed
+        }
+
+        fn sleep(&self, duration: Duration) {
+            let mut state = self.state.lock().unwrap();
+            state.sleeps.push(duration);
+            state.now += chrono::Duration::from_std(duration).unwrap();
+            state.elapsed += duration;
+        }
+    }
+
+    struct FakeEventSource {
+        events: Mutex<VecDeque<Result<DaemonEvent, WaitError>>>,
+        drained_inbox: Mutex<u32>,
+    }
+
+    impl FakeEventSource {
+        fn new(events: Vec<Result<DaemonEvent, WaitError>>) -> Self {
+            Self {
+                events: Mutex::new(events.into()),
+                drained_inbox: Mutex::new(0),
+            }
+        }
+
+        fn drained_count(&self) -> u32 {
+            *self.drained_inbox.lock().unwrap()
+        }
+    }
+
+    struct FakeSessionRuntime {
+        requests: Mutex<VecDeque<anyhow::Result<Option<crate::socket::Request>>>>,
+        waits: Mutex<VecDeque<std::io::Result<Option<ChildExitStatus>>>>,
+        responses: Mutex<Vec<(bool, String)>>,
+        terminated: AtomicBool,
+    }
+
+    impl FakeSessionRuntime {
+        fn new(
+            requests: Vec<anyhow::Result<Option<crate::socket::Request>>>,
+            waits: Vec<std::io::Result<Option<ChildExitStatus>>>,
+        ) -> Self {
+            Self {
+                requests: Mutex::new(requests.into()),
+                waits: Mutex::new(waits.into()),
+                responses: Mutex::new(Vec::new()),
+                terminated: AtomicBool::new(false),
+            }
+        }
+
+        fn responses(&self) -> Vec<(bool, String)> {
+            self.responses.lock().unwrap().clone()
+        }
+
+        fn terminated(&self) -> bool {
+            self.terminated.load(Ordering::Relaxed)
+        }
+    }
+
+    impl SessionRuntime for FakeSessionRuntime {
+        fn accept_request(
+            &mut self,
+            _expected_instance_id: Option<&str>,
+        ) -> Result<Option<crate::socket::Request>> {
+            self.requests
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(Ok(None))
+        }
+
+        fn respond(&mut self, ok: bool, message: String) -> Result<()> {
+            self.responses.lock().unwrap().push((ok, message));
+            Ok(())
+        }
+
+        fn try_wait(&mut self) -> std::io::Result<Option<ChildExitStatus>> {
+            self.waits.lock().unwrap().pop_front().unwrap_or(Ok(None))
+        }
+
+        fn terminate(&mut self) {
+            self.terminated.store(true, Ordering::Relaxed);
+        }
+    }
+
+    struct FakeSessionEffects {
+        reply_failure: Option<String>,
+        replies: Vec<(String, NaiveDateTime)>,
+        todos: Vec<crate::todo::TodoItem>,
+        next_todo_id: u32,
+        archived_batches: Vec<Vec<String>>,
+    }
+
+    impl FakeSessionEffects {
+        fn new() -> Self {
+            Self {
+                reply_failure: None,
+                replies: Vec::new(),
+                todos: Vec::new(),
+                next_todo_id: 1,
+                archived_batches: Vec::new(),
+            }
+        }
+
+        fn with_reply_failure(message: &str) -> Self {
+            let mut effects = Self::new();
+            effects.reply_failure = Some(message.to_string());
+            effects
+        }
+    }
+
+    impl SessionEffects for FakeSessionEffects {
+        fn archive_inbox(&mut self, inbox_filenames: &[String]) -> Result<()> {
+            self.archived_batches.push(inbox_filenames.to_vec());
+            Ok(())
+        }
+
+        fn write_reply(&mut self, text: &str, timestamp: NaiveDateTime) -> Result<()> {
+            if let Some(message) = &self.reply_failure {
+                anyhow::bail!("{message}");
+            }
+            self.replies.push((text.to_string(), timestamp));
+            Ok(())
+        }
+
+        fn todo_add(&mut self, text: &str, at: &str) -> Result<u32> {
+            let id = self.next_todo_id;
+            self.next_todo_id += 1;
+            self.todos.push(crate::todo::TodoItem {
+                id,
+                text: text.to_string(),
+                done: false,
+                at: at.to_string(),
+                created: "unknown".to_string(),
+            });
+            Ok(id)
+        }
+
+        fn todo_done(&mut self, id: u32) -> Result<()> {
+            let item = self
+                .todos
+                .iter_mut()
+                .find(|item| item.id == id)
+                .ok_or_else(|| anyhow::anyhow!("TODO #{id} not found"))?;
+            item.done = true;
+            Ok(())
+        }
+
+        fn todo_remove(&mut self, id: u32) -> Result<()> {
+            let len_before = self.todos.len();
+            self.todos.retain(|item| item.id != id);
+            if self.todos.len() == len_before {
+                anyhow::bail!("TODO #{id} not found");
+            }
+            Ok(())
+        }
+
+        fn todo_list(&mut self) -> Result<String> {
+            if self.todos.is_empty() {
+                return Ok("No todos.".to_string());
+            }
+            Ok(self
+                .todos
+                .iter()
+                .map(|item| {
+                    let check = if item.done { "x" } else { " " };
+                    format!("{}. [{}] {} (at: {})", item.id, check, item.text, item.at)
+                })
+                .collect::<Vec<_>>()
+                .join("\n"))
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct DummyServer;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct DummyWatcher;
+
+    struct FakeStartupPlatform {
+        signal_error: Option<String>,
+        bind_error: Option<String>,
+        registry_error: Option<String>,
+        watcher_error: Option<String>,
+        bind_calls: Mutex<u32>,
+        watcher_calls: Mutex<u32>,
+    }
+
+    impl FakeStartupPlatform {
+        fn new() -> Self {
+            Self {
+                signal_error: None,
+                bind_error: None,
+                registry_error: None,
+                watcher_error: None,
+                bind_calls: Mutex::new(0),
+                watcher_calls: Mutex::new(0),
+            }
+        }
+
+        fn bind_calls(&self) -> u32 {
+            *self.bind_calls.lock().unwrap()
+        }
+
+        fn watcher_calls(&self) -> u32 {
+            *self.watcher_calls.lock().unwrap()
+        }
+    }
+
+    impl StartupPlatform for FakeStartupPlatform {
+        type Server = DummyServer;
+        type Watcher = DummyWatcher;
+
+        fn register_signal_handlers(
+            &self,
+            _shutdown: &Arc<AtomicBool>,
+            _wake_requested: &Arc<AtomicBool>,
+        ) -> Result<()> {
+            if let Some(message) = &self.signal_error {
+                anyhow::bail!("{message}");
+            }
+            Ok(())
+        }
+
+        fn bind_socket_server(&self, _sock_path: &Path) -> Result<Self::Server> {
+            *self.bind_calls.lock().unwrap() += 1;
+            if let Some(message) = &self.bind_error {
+                anyhow::bail!("{message}");
+            }
+            Ok(DummyServer)
+        }
+
+        fn register_registry(&self, _dir: &Path, _sock_path: &Path) -> Result<()> {
+            if let Some(message) = &self.registry_error {
+                anyhow::bail!("{message}");
+            }
+            Ok(())
+        }
+
+        fn start_inbox_watcher(
+            &self,
+            _inbox_path: &Path,
+            _tx: mpsc::Sender<DaemonEvent>,
+        ) -> Result<Self::Watcher> {
+            *self.watcher_calls.lock().unwrap() += 1;
+            if let Some(message) = &self.watcher_error {
+                anyhow::bail!("{message}");
+            }
+            Ok(DummyWatcher)
+        }
+    }
+
+    fn test_cryo_state() -> CryoState {
+        CryoState {
+            session_number: 1,
+            pid: None,
+            retry_count: 0,
+            agent_override: None,
+            max_retries_override: None,
+            max_session_duration_override: None,
+            last_report_time: None,
+            provider_index: None,
+            instance_id: Some("test-instance".into()),
+            pending_fallback: None,
+        }
+    }
+
+    fn begin_test_logger(dir: &Path) -> crate::log::EventLogger {
+        crate::log::EventLogger::begin(&dir.join("cryo.log"), 1, "test task", "mock-agent", &[])
+            .unwrap()
+    }
+
+    fn test_session_context<'a>(
+        cryo_state: &'a CryoState,
+        timeout_secs: u64,
+        spawn_time: Instant,
+        inbox_filenames: &'a [String],
+    ) -> ActiveSessionContext<'a> {
+        ActiveSessionContext {
+            cryo_state,
+            timeout_secs,
+            spawn_time,
+            inbox_filenames,
+        }
+    }
+
+    impl EventSource for FakeEventSource {
+        fn recv_timeout(&self, _timeout: Duration) -> Result<DaemonEvent, WaitError> {
+            self.events
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(Err(WaitError::Timeout))
+        }
+
+        fn drain_inbox_changed(&self) {
+            let mut events = self.events.lock().unwrap();
+            while matches!(events.front(), Some(Ok(DaemonEvent::InboxChanged))) {
+                events.pop_front();
+                *self.drained_inbox.lock().unwrap() += 1;
+            }
+        }
+    }
 
     #[test]
     fn test_backoff_sequence() {
@@ -1252,6 +2224,53 @@ mod tests {
     }
 
     #[test]
+    fn test_wait_for_idle_event_coalesces_inbox_changes() {
+        let source = FakeEventSource::new(vec![
+            Ok(DaemonEvent::InboxChanged),
+            Ok(DaemonEvent::InboxChanged),
+            Ok(DaemonEvent::InboxChanged),
+        ]);
+
+        let outcome = wait_for_idle_event(&source, Duration::from_secs(1), true);
+
+        assert_eq!(outcome, IdleWaitOutcome::WakeFromInbox);
+        assert_eq!(source.drained_count(), 2);
+    }
+
+    #[test]
+    fn test_wait_for_idle_event_timeout_with_scheduled_wake() {
+        let source = FakeEventSource::new(vec![Err(WaitError::Timeout)]);
+
+        let outcome = wait_for_idle_event(&source, Duration::from_secs(1), true);
+
+        assert_eq!(outcome, IdleWaitOutcome::WakeFromSchedule);
+    }
+
+    #[test]
+    fn test_wait_for_idle_event_timeout_without_scheduled_wake() {
+        let source = FakeEventSource::new(vec![Err(WaitError::Timeout)]);
+
+        let outcome = wait_for_idle_event(&source, Duration::from_secs(1), false);
+
+        assert_eq!(outcome, IdleWaitOutcome::StayIdle);
+    }
+
+    #[test]
+    fn test_wait_for_idle_event_shutdown_and_disconnect() {
+        let shutdown = FakeEventSource::new(vec![Ok(DaemonEvent::Shutdown)]);
+        let disconnected = FakeEventSource::new(vec![Err(WaitError::Disconnected)]);
+
+        assert_eq!(
+            wait_for_idle_event(&shutdown, Duration::from_secs(1), true),
+            IdleWaitOutcome::Shutdown
+        );
+        assert_eq!(
+            wait_for_idle_event(&disconnected, Duration::from_secs(1), true),
+            IdleWaitOutcome::Disconnected
+        );
+    }
+
+    #[test]
     fn test_delayed_wake_under_threshold() {
         let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
             .unwrap()
@@ -1362,5 +2381,727 @@ mod tests {
         list.save(&path).unwrap();
         let wake = next_wake_from_todos(dir.path());
         assert!(wake.is_none(), "All invalid entries should yield None");
+    }
+
+    #[test]
+    fn test_sleep_or_shutdown_uses_injected_clock() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock.clone());
+
+        assert!(!daemon.sleep_or_shutdown(Duration::from_millis(600)));
+        assert_eq!(
+            clock.sleeps(),
+            vec![
+                Duration::from_millis(250),
+                Duration::from_millis(250),
+                Duration::from_millis(100),
+            ]
+        );
+        assert_eq!(clock.local_now(), now + chrono::Duration::milliseconds(600));
+    }
+
+    #[test]
+    fn test_check_fallback_uses_injected_clock() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::message::ensure_dirs(dir.path()).unwrap();
+
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock.clone());
+
+        let action = FallbackAction {
+            action: "email".to_string(),
+            target: "ops@example.com".to_string(),
+            message: "still waiting".to_string(),
+        };
+        let mut cryo_state = CryoState {
+            session_number: 1,
+            pid: None,
+            retry_count: 0,
+            agent_override: None,
+            max_retries_override: None,
+            max_session_duration_override: None,
+            last_report_time: None,
+            provider_index: None,
+            instance_id: None,
+            pending_fallback: Some(PendingFallbackState {
+                deadline: (now + chrono::Duration::minutes(1))
+                    .format(FALLBACK_TIME_FMT)
+                    .to_string(),
+                action: action.clone(),
+            }),
+        };
+        let mut pending = Some((now + chrono::Duration::minutes(1), action));
+
+        daemon.check_fallback(&mut cryo_state, &mut pending, "outbox");
+        assert!(
+            pending.is_some(),
+            "Fallback should not fire before the deadline"
+        );
+
+        clock.advance(Duration::from_secs(61));
+        daemon.check_fallback(&mut cryo_state, &mut pending, "outbox");
+
+        assert!(
+            pending.is_none(),
+            "Fallback should fire after fake time advances"
+        );
+        assert!(cryo_state.pending_fallback.is_none());
+        let outbox = crate::message::read_outbox(dir.path()).unwrap();
+        assert_eq!(outbox.len(), 1, "Fallback should write one outbox message");
+    }
+
+    #[test]
+    fn test_resolve_hibernate_request_failure_retries() {
+        let mut pending_fallback = Some(FallbackAction {
+            action: "email".into(),
+            target: "ops@example.com".into(),
+            message: "stuck".into(),
+        });
+
+        let decision =
+            resolve_hibernate_request(false, 7, Some("provider failed"), &mut pending_fallback);
+
+        assert_eq!(
+            decision.outcome,
+            SessionLoopOutcome::ValidationFailed { quick_exit: false }
+        );
+        assert_eq!(
+            decision.response_message,
+            "Failure recorded. Daemon will retry."
+        );
+        assert_eq!(
+            decision.log_event,
+            "hibernate failed: exit=7, summary=\"provider failed\""
+        );
+        assert!(
+            pending_fallback.is_some(),
+            "failure should not consume fallback"
+        );
+    }
+
+    #[test]
+    fn test_resolve_hibernate_request_complete_ignores_fallback() {
+        let mut pending_fallback = Some(FallbackAction {
+            action: "email".into(),
+            target: "ops@example.com".into(),
+            message: "stuck".into(),
+        });
+
+        let decision = resolve_hibernate_request(true, 0, None, &mut pending_fallback);
+
+        assert_eq!(decision.outcome, SessionLoopOutcome::PlanComplete);
+        assert_eq!(decision.response_message, "Plan complete. Shutting down.");
+        assert_eq!(
+            decision.log_event,
+            "hibernate: plan complete, exit=0, summary=\"(no summary)\""
+        );
+        assert!(
+            pending_fallback.is_some(),
+            "complete should not consume fallback"
+        );
+    }
+
+    #[test]
+    fn test_resolve_hibernate_request_uses_pending_fallback() {
+        let fallback = FallbackAction {
+            action: "webhook".into(),
+            target: "ops".into(),
+            message: "waiting".into(),
+        };
+        let mut pending_fallback = Some(fallback.clone());
+
+        let decision =
+            resolve_hibernate_request(false, 0, Some("waiting on reply"), &mut pending_fallback);
+
+        assert_eq!(
+            decision.outcome,
+            SessionLoopOutcome::Hibernate {
+                fallback: Some(fallback),
+            }
+        );
+        assert_eq!(decision.response_message, "Hibernating.");
+        assert_eq!(
+            decision.log_event,
+            "hibernate: exit=0, summary=\"waiting on reply\""
+        );
+        assert!(
+            pending_fallback.is_none(),
+            "successful hibernate should consume pending fallback"
+        );
+    }
+
+    #[test]
+    fn test_resolve_interrupted_session_prefers_hibernate_outcome() {
+        let hibernate = SessionLoopOutcome::Hibernate { fallback: None };
+
+        let shutdown =
+            resolve_interrupted_session(SessionInterruption::Shutdown, Some(hibernate.clone()));
+        let timeout = resolve_interrupted_session(SessionInterruption::Timeout, Some(hibernate));
+
+        assert_eq!(
+            shutdown.outcome,
+            SessionLoopOutcome::Hibernate { fallback: None }
+        );
+        assert_eq!(
+            shutdown.finish_reason,
+            "daemon shutdown — using agent's hibernate outcome"
+        );
+        assert_eq!(
+            timeout.outcome,
+            SessionLoopOutcome::Hibernate { fallback: None }
+        );
+        assert_eq!(
+            timeout.finish_reason,
+            "session timeout — using agent's hibernate outcome"
+        );
+    }
+
+    #[test]
+    fn test_resolve_interrupted_session_without_hibernate_fails() {
+        let shutdown = resolve_interrupted_session(SessionInterruption::Shutdown, None);
+        let timeout = resolve_interrupted_session(SessionInterruption::Timeout, None);
+
+        assert_eq!(
+            shutdown.outcome,
+            SessionLoopOutcome::ValidationFailed { quick_exit: false }
+        );
+        assert_eq!(shutdown.finish_reason, "daemon shutdown — agent terminated");
+        assert_eq!(
+            timeout.outcome,
+            SessionLoopOutcome::ValidationFailed { quick_exit: false }
+        );
+        assert_eq!(timeout.finish_reason, "session timeout — agent killed");
+    }
+
+    #[test]
+    fn test_resolve_child_exit_after_hibernate_returns_outcome() {
+        let decision = resolve_child_exit(
+            Some(SessionLoopOutcome::PlanComplete),
+            Duration::from_secs(1),
+        );
+
+        assert_eq!(decision.outcome, SessionLoopOutcome::PlanComplete);
+        assert_eq!(decision.finish_reason, "session complete");
+        assert!(!decision.quick_exit);
+    }
+
+    #[test]
+    fn test_resolve_child_exit_without_hibernate_marks_quick_exit() {
+        let quick = resolve_child_exit(None, Duration::from_secs(2));
+        let slow = resolve_child_exit(None, Duration::from_secs(8));
+
+        assert_eq!(
+            quick.outcome,
+            SessionLoopOutcome::ValidationFailed { quick_exit: true }
+        );
+        assert_eq!(quick.finish_reason, "agent exited without hibernate");
+        assert!(quick.quick_exit);
+
+        assert_eq!(
+            slow.outcome,
+            SessionLoopOutcome::ValidationFailed { quick_exit: false }
+        );
+        assert_eq!(slow.finish_reason, "agent exited without hibernate");
+        assert!(!slow.quick_exit);
+    }
+
+    #[test]
+    fn test_drive_active_session_alert_then_hibernate_returns_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::message::ensure_dirs(dir.path()).unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock.clone());
+        let cryo_state = test_cryo_state();
+        let mut runtime = FakeSessionRuntime::new(
+            vec![
+                Ok(Some(crate::socket::Request::Alert {
+                    action: "webhook".into(),
+                    target: "ops".into(),
+                    message: "waiting".into(),
+                })),
+                Ok(Some(crate::socket::Request::Hibernate {
+                    complete: false,
+                    exit_code: 0,
+                    summary: Some("waiting on reply".into()),
+                })),
+            ],
+            vec![Ok(None), Ok(Some(ChildExitStatus { code: Some(0) }))],
+        );
+        let mut effects = FakeSessionEffects::new();
+
+        let outcome = daemon
+            .drive_active_session(
+                &mut runtime,
+                &mut effects,
+                test_session_context(&cryo_state, 60, clock.monotonic_now(), &[]),
+                begin_test_logger(dir.path()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            SessionLoopOutcome::Hibernate {
+                fallback: Some(FallbackAction {
+                    action: "webhook".into(),
+                    target: "ops".into(),
+                    message: "waiting".into(),
+                }),
+            }
+        );
+        assert_eq!(
+            runtime.responses(),
+            vec![
+                (true, "Alert registered".into()),
+                (true, "Hibernating.".into()),
+            ]
+        );
+        assert!(!runtime.terminated());
+    }
+
+    #[test]
+    fn test_drive_active_session_timeout_after_hibernate_uses_hibernate_outcome() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::message::ensure_dirs(dir.path()).unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock.clone());
+        let cryo_state = test_cryo_state();
+        let mut runtime = FakeSessionRuntime::new(
+            vec![Ok(Some(crate::socket::Request::Hibernate {
+                complete: false,
+                exit_code: 0,
+                summary: Some("waiting".into()),
+            }))],
+            vec![],
+        );
+        let mut effects = FakeSessionEffects::new();
+
+        let outcome = daemon
+            .drive_active_session(
+                &mut runtime,
+                &mut effects,
+                test_session_context(&cryo_state, 1, clock.monotonic_now(), &[]),
+                begin_test_logger(dir.path()),
+            )
+            .unwrap();
+
+        assert_eq!(outcome, SessionLoopOutcome::Hibernate { fallback: None });
+        assert!(runtime.terminated(), "timeout should terminate the child");
+        assert_eq!(runtime.responses(), vec![(true, "Hibernating.".into())]);
+    }
+
+    #[test]
+    fn test_drive_active_session_quick_exit_without_hibernate() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock.clone());
+        let cryo_state = test_cryo_state();
+        let mut runtime =
+            FakeSessionRuntime::new(vec![], vec![Ok(Some(ChildExitStatus { code: Some(1) }))]);
+        let mut effects = FakeSessionEffects::new();
+
+        let outcome = daemon
+            .drive_active_session(
+                &mut runtime,
+                &mut effects,
+                test_session_context(&cryo_state, 60, clock.monotonic_now(), &[]),
+                begin_test_logger(dir.path()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            SessionLoopOutcome::ValidationFailed { quick_exit: true }
+        );
+        assert!(!runtime.terminated());
+        assert!(runtime.responses().is_empty());
+    }
+
+    #[test]
+    fn test_drive_active_session_reply_failure_responds_and_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock.clone());
+        let cryo_state = test_cryo_state();
+        let mut runtime = FakeSessionRuntime::new(
+            vec![
+                Ok(Some(crate::socket::Request::Reply {
+                    text: "Need approval".into(),
+                })),
+                Ok(Some(crate::socket::Request::Hibernate {
+                    complete: false,
+                    exit_code: 0,
+                    summary: Some("waiting".into()),
+                })),
+            ],
+            vec![
+                Ok(None),
+                Ok(None),
+                Ok(Some(ChildExitStatus { code: Some(0) })),
+            ],
+        );
+        let mut effects = FakeSessionEffects::with_reply_failure("injected reply failure");
+
+        let outcome = daemon
+            .drive_active_session(
+                &mut runtime,
+                &mut effects,
+                test_session_context(&cryo_state, 60, clock.monotonic_now(), &[]),
+                begin_test_logger(dir.path()),
+            )
+            .unwrap();
+
+        assert_eq!(outcome, SessionLoopOutcome::Hibernate { fallback: None });
+        assert_eq!(
+            runtime.responses(),
+            vec![
+                (
+                    false,
+                    "Failed to write reply: injected reply failure".into()
+                ),
+                (true, "Hibernating.".into()),
+            ]
+        );
+        assert!(effects.replies.is_empty());
+    }
+
+    #[test]
+    fn test_drive_active_session_todo_requests_use_effects() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock.clone());
+        let cryo_state = test_cryo_state();
+        let mut runtime = FakeSessionRuntime::new(
+            vec![
+                Ok(Some(crate::socket::Request::TodoAdd {
+                    text: "Check inbox".into(),
+                    at: "2026-03-01T13:00".into(),
+                })),
+                Ok(Some(crate::socket::Request::TodoList)),
+                Ok(Some(crate::socket::Request::TodoDone { id: 1 })),
+                Ok(Some(crate::socket::Request::TodoRemove { id: 1 })),
+                Ok(Some(crate::socket::Request::Hibernate {
+                    complete: false,
+                    exit_code: 0,
+                    summary: None,
+                })),
+            ],
+            vec![
+                Ok(None),
+                Ok(None),
+                Ok(None),
+                Ok(None),
+                Ok(None),
+                Ok(Some(ChildExitStatus { code: Some(0) })),
+            ],
+        );
+        let mut effects = FakeSessionEffects::new();
+
+        let outcome = daemon
+            .drive_active_session(
+                &mut runtime,
+                &mut effects,
+                test_session_context(&cryo_state, 60, clock.monotonic_now(), &[]),
+                begin_test_logger(dir.path()),
+            )
+            .unwrap();
+
+        assert_eq!(outcome, SessionLoopOutcome::Hibernate { fallback: None });
+        assert_eq!(
+            runtime.responses(),
+            vec![
+                (true, "Added todo #1".into()),
+                (true, "1. [ ] Check inbox (at: 2026-03-01T13:00)".into()),
+                (true, "Marked todo #1 as done".into()),
+                (true, "Removed todo #1".into()),
+                (true, "Hibernating.".into()),
+            ]
+        );
+        assert!(effects.todos.is_empty());
+    }
+
+    #[test]
+    fn test_drive_active_session_timeout_archives_inbox_via_effects() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock.clone());
+        let cryo_state = test_cryo_state();
+        let mut runtime = FakeSessionRuntime::new(vec![], vec![]);
+        let mut effects = FakeSessionEffects::new();
+        let inbox = vec!["msg-1.md".to_string(), "msg-2.md".to_string()];
+
+        let outcome = daemon
+            .drive_active_session(
+                &mut runtime,
+                &mut effects,
+                test_session_context(&cryo_state, 1, clock.monotonic_now(), &inbox),
+                begin_test_logger(dir.path()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            SessionLoopOutcome::ValidationFailed { quick_exit: false }
+        );
+        assert!(runtime.terminated());
+        assert_eq!(effects.archived_batches, vec![inbox]);
+    }
+
+    #[test]
+    fn test_build_bootstrap_state_clears_invalid_pending_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock);
+        let mut cryo_state = test_cryo_state();
+        cryo_state.pending_fallback = Some(PendingFallbackState {
+            deadline: "not-a-time".into(),
+            action: FallbackAction {
+                action: "email".into(),
+                target: "ops@example.com".into(),
+                message: "stuck".into(),
+            },
+        });
+
+        let bootstrap = daemon.build_bootstrap_state(&mut cryo_state, &CryoConfig::default());
+
+        assert!(bootstrap.pending_fallback.is_none());
+        assert!(bootstrap.cleared_invalid_pending_fallback);
+        assert!(cryo_state.pending_fallback.is_none());
+    }
+
+    #[test]
+    fn test_build_bootstrap_state_runs_immediately_for_first_session_and_overdue_wake() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock);
+        let mut first_session = test_cryo_state();
+        first_session.session_number = 0;
+
+        let first = daemon.build_bootstrap_state(&mut first_session, &CryoConfig::default());
+        assert!(first.run_now);
+
+        let todo_path = dir.path().join("todo.json");
+        let mut todos = crate::todo::TodoList::new();
+        todos.add("Overdue task".into(), "2026-03-01T11:30".into());
+        todos.save(&todo_path).unwrap();
+
+        let mut resumed = test_cryo_state();
+        resumed.session_number = 3;
+        let resumed_bootstrap = daemon.build_bootstrap_state(&mut resumed, &CryoConfig::default());
+        assert_eq!(
+            resumed_bootstrap.next_wake,
+            Some(
+                chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+                    .unwrap()
+                    .and_hms_opt(11, 30, 0)
+                    .unwrap()
+            )
+        );
+        assert!(resumed_bootstrap.run_now);
+    }
+
+    #[test]
+    fn test_build_bootstrap_state_only_enables_watcher_when_configured_and_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock);
+        let mut cryo_state = test_cryo_state();
+        let mut config = CryoConfig::default();
+
+        let no_inbox = daemon.build_bootstrap_state(&mut cryo_state, &config);
+        assert!(no_inbox.watch_inbox_path.is_none());
+
+        let inbox = dir.path().join("messages").join("inbox");
+        std::fs::create_dir_all(&inbox).unwrap();
+        let with_inbox = daemon.build_bootstrap_state(&mut cryo_state, &config);
+        assert_eq!(with_inbox.watch_inbox_path, Some(inbox.clone()));
+
+        config.watch_inbox = false;
+        let disabled = daemon.build_bootstrap_state(&mut cryo_state, &config);
+        assert!(disabled.watch_inbox_path.is_none());
+    }
+
+    #[test]
+    fn test_prepare_shutdown_state_clears_runtime_identity_and_syncs_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock);
+        let mut cryo_state = test_cryo_state();
+        cryo_state.pid = Some(1234);
+        cryo_state.instance_id = Some("daemon-1".into());
+        let pending = Some((
+            now + chrono::Duration::hours(1),
+            FallbackAction {
+                action: "webhook".into(),
+                target: "ops".into(),
+                message: "still waiting".into(),
+            },
+        ));
+
+        daemon.prepare_shutdown_state(&mut cryo_state, pending.as_ref());
+
+        assert!(cryo_state.pid.is_none());
+        assert!(cryo_state.instance_id.is_none());
+        assert_eq!(
+            cryo_state.pending_fallback,
+            Some(PendingFallbackState {
+                deadline: "2026-03-01T13:00:00".into(),
+                action: FallbackAction {
+                    action: "webhook".into(),
+                    target: "ops".into(),
+                    message: "still waiting".into(),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn test_prepare_runtime_startup_returns_registry_warning_but_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock);
+        let inbox = dir.path().join("messages").join("inbox");
+        std::fs::create_dir_all(&inbox).unwrap();
+        let mut platform = FakeStartupPlatform::new();
+        platform.registry_error = Some("registry unavailable".into());
+        let (tx, _rx) = mpsc::channel();
+
+        let startup = daemon
+            .prepare_runtime_startup(&platform, Some(inbox.as_path()), tx)
+            .unwrap();
+
+        assert_eq!(
+            startup.diagnostics.registry_warning,
+            Some("registry unavailable".into())
+        );
+        assert!(startup.diagnostics.watcher_warning.is_none());
+        assert_eq!(platform.bind_calls(), 1);
+        assert_eq!(platform.watcher_calls(), 1);
+        assert!(startup.watcher.is_some());
+    }
+
+    #[test]
+    fn test_prepare_runtime_startup_watcher_failure_is_nonfatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock);
+        let inbox = dir.path().join("messages").join("inbox");
+        std::fs::create_dir_all(&inbox).unwrap();
+        let mut platform = FakeStartupPlatform::new();
+        platform.watcher_error = Some("watch failed".into());
+        let (tx, _rx) = mpsc::channel();
+
+        let startup = daemon
+            .prepare_runtime_startup(&platform, Some(inbox.as_path()), tx)
+            .unwrap();
+
+        assert!(startup.watcher.is_none());
+        assert_eq!(
+            startup.diagnostics.watcher_warning,
+            Some("watch failed".into())
+        );
+        assert_eq!(platform.watcher_calls(), 1);
+    }
+
+    #[test]
+    fn test_prepare_runtime_startup_propagates_signal_registration_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock);
+        let mut platform = FakeStartupPlatform::new();
+        platform.signal_error = Some("signal registration failed".into());
+        let (tx, _rx) = mpsc::channel();
+
+        let error = daemon
+            .prepare_runtime_startup(&platform, None, tx)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("signal registration failed"));
+        assert_eq!(platform.bind_calls(), 0);
+        assert_eq!(platform.watcher_calls(), 0);
+    }
+
+    #[test]
+    fn test_prepare_runtime_startup_propagates_socket_bind_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let clock = Arc::new(TestClock::new(now));
+        let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock);
+        let mut platform = FakeStartupPlatform::new();
+        platform.bind_error = Some("bind failed".into());
+        let (tx, _rx) = mpsc::channel();
+
+        let error = daemon
+            .prepare_runtime_startup(&platform, None, tx)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("bind failed"));
+        assert_eq!(platform.bind_calls(), 1);
+        assert_eq!(platform.watcher_calls(), 0);
     }
 }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -1,13 +1,14 @@
 // src/fallback.rs
 use anyhow::Result;
 use chrono::Local;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::Path;
 
 use crate::message::{self, Message};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FallbackAction {
     pub action: String,
     pub target: String,

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,6 +3,9 @@ use anyhow::{Context, Result};
 use chrono::{Local, NaiveDateTime};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static MESSAGE_SEQ: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
 pub struct Message {
@@ -29,18 +32,12 @@ pub fn write_message(dir: &Path, box_name: &str, msg: &Message) -> Result<PathBu
 
     let slug = slugify(&msg.subject);
     let ts = msg.timestamp.format("%Y-%m-%dT%H-%M-%S");
-    // When slug is empty (e.g. GitHub comments with no subject), use a short
-    // hash of the body to avoid filename collisions within the same second.
-    let disambig = if slug.is_empty() {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        msg.body.hash(&mut hasher);
-        msg.from.hash(&mut hasher);
-        format!("{:08x}", hasher.finish() as u32)
+    let base = if slug.is_empty() {
+        message_hash(msg)
     } else {
         slug
     };
-    let filename = format!("{ts}_{disambig}.md");
+    let filename = format!("{ts}_{base}_{}.md", unique_suffix());
     let path = box_dir.join(&filename);
 
     // Atomic write: write to tmp, then rename
@@ -50,6 +47,25 @@ pub fn write_message(dir: &Path, box_name: &str, msg: &Message) -> Result<PathBu
     std::fs::rename(&tmp_path, &path)?;
 
     Ok(path)
+}
+
+fn message_hash(msg: &Message) -> String {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    msg.body.hash(&mut hasher);
+    msg.from.hash(&mut hasher);
+    msg.subject.hash(&mut hasher);
+    format!("{:08x}", hasher.finish() as u32)
+}
+
+fn unique_suffix() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = MESSAGE_SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("{nanos:032x}_{:08x}_{seq:04x}", std::process::id())
 }
 
 /// Read all unread messages from inbox/, sorted by filename (timestamp order).

--- a/src/process.rs
+++ b/src/process.rs
@@ -19,7 +19,8 @@ pub fn send_signal(pid: u32, signal: i32) -> bool {
 pub fn signal_daemon_wake(dir: &Path) -> bool {
     if let Ok(Some(st)) = crate::state::load_state(&crate::state::state_path(dir)) {
         if let Some(pid) = st.pid {
-            if crate::state::is_locked(&st) {
+            let reachable = matches!(crate::socket::send_request(dir, &crate::socket::Request::Ping), Ok(resp) if resp.ok);
+            if crate::state::is_locked(&st) && reachable {
                 return send_signal(pid, libc::SIGUSR1);
             }
         }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -5,9 +5,10 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 /// Request from CLI to daemon via Unix socket.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 pub enum Request {
+    Ping,
     Hibernate {
         complete: bool,
         exit_code: u8,
@@ -44,6 +45,14 @@ pub struct Response {
     pub message: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct SocketEnvelope {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    instance_id: Option<String>,
+    #[serde(flatten)]
+    request: Request,
+}
+
 /// Returns the socket path for a project directory.
 pub fn socket_path(dir: &Path) -> PathBuf {
     dir.join(".cryo").join("cryo.sock")
@@ -56,7 +65,16 @@ pub fn send_request(dir: &Path, request: &Request) -> anyhow::Result<Response> {
         anyhow::anyhow!("Cannot connect to daemon socket at {}: {e}", path.display())
     })?;
 
-    let mut payload = serde_json::to_string(request)?;
+    let instance_id = crate::state::load_state(&crate::state::state_path(dir))
+        .ok()
+        .flatten()
+        .and_then(|state| state.instance_id);
+    let envelope = SocketEnvelope {
+        instance_id,
+        request: request.clone(),
+    };
+
+    let mut payload = serde_json::to_string(&envelope)?;
     payload.push('\n');
     stream.write_all(payload.as_bytes())?;
     stream.flush()?;
@@ -99,7 +117,10 @@ impl SocketServer {
     }
 
     /// Accept one connection, parse the request, return it with a responder.
-    pub fn accept_one(&self) -> anyhow::Result<Option<(Request, Responder)>> {
+    pub fn accept_one(
+        &self,
+        expected_instance_id: Option<&str>,
+    ) -> anyhow::Result<Option<(Request, Responder)>> {
         let (stream, _) = self.listener.accept()?;
         let mut reader = BufReader::new(stream.try_clone()?);
         let mut line = String::new();
@@ -107,8 +128,19 @@ impl SocketServer {
         if line.trim().is_empty() {
             return Ok(None);
         }
-        let request: Request = serde_json::from_str(line.trim())?;
-        Ok(Some((request, Responder { stream })))
+        let envelope: SocketEnvelope = serde_json::from_str(line.trim())?;
+        let responder = Responder { stream };
+        if let Some(expected) = expected_instance_id {
+            if envelope.instance_id.as_deref() != Some(expected) {
+                responder.respond(&Response {
+                    ok: false,
+                    message: "Daemon instance mismatch. The state file is stale; reload and retry."
+                        .to_string(),
+                })?;
+                return Ok(None);
+            }
+        }
+        Ok(Some((envelope.request, responder)))
     }
 
     /// Set the listener to non-blocking mode.
@@ -131,6 +163,7 @@ impl SocketServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::{save_state, CryoState};
 
     #[test]
     fn test_serialize_hibernate_request() {
@@ -212,7 +245,7 @@ mod tests {
 
         // Spawn server handler in a thread
         let handle = std::thread::spawn(move || {
-            if let Some((req, responder)) = server.accept_one().unwrap() {
+            if let Some((req, responder)) = server.accept_one(None).unwrap() {
                 tx.send(req).unwrap();
                 responder
                     .respond(&Response {
@@ -224,6 +257,19 @@ mod tests {
         });
 
         // Client sends a request
+        let state = CryoState {
+            session_number: 1,
+            pid: None,
+            retry_count: 0,
+            agent_override: None,
+            max_retries_override: None,
+            max_session_duration_override: None,
+            last_report_time: None,
+            provider_index: None,
+            instance_id: Some("instance-123".to_string()),
+            pending_fallback: None,
+        };
+        save_state(&dir.path().join("timer.json"), &state).unwrap();
         let resp = send_request(
             dir.path(),
             &Request::Note {
@@ -258,7 +304,7 @@ mod tests {
             }
         });
 
-        let result = server.accept_one().unwrap();
+        let result = server.accept_one(None).unwrap();
         assert!(result.is_none(), "Empty line should return None");
         handle.join().unwrap();
     }
@@ -280,7 +326,7 @@ mod tests {
             }
         });
 
-        let result = server.accept_one();
+        let result = server.accept_one(None);
         assert!(result.is_err(), "Malformed JSON should return error");
         handle.join().unwrap();
     }
@@ -309,7 +355,7 @@ mod tests {
             }
         });
 
-        let result = server.accept_one();
+        let result = server.accept_one(None);
         // serde ignores unknown fields by default (no deny_unknown_fields set)
         match result {
             Ok(Some((req, responder))) => {
@@ -325,6 +371,42 @@ mod tests {
             Err(e) => panic!("Should not error for unknown fields: {e}"),
         }
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn test_accept_one_rejects_mismatched_instance_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let server = SocketServer::bind(&sock_path).unwrap();
+        server.set_nonblocking(false).unwrap();
+
+        let handle = std::thread::spawn({
+            let sock_path = sock_path.clone();
+            move || {
+                let mut stream = std::os::unix::net::UnixStream::connect(&sock_path).unwrap();
+                use std::io::{BufRead, BufReader, Write};
+                let json = r#"{"instance_id":"wrong-instance","cmd":"note","text":"hello"}"#;
+                stream.write_all(json.as_bytes()).unwrap();
+                stream.write_all(b"\n").unwrap();
+                stream.flush().unwrap();
+
+                let mut reader = BufReader::new(stream);
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                line
+            }
+        });
+
+        let result = server.accept_one(Some("expected-instance")).unwrap();
+        assert!(
+            result.is_none(),
+            "Mismatched instance should be rejected before reaching the daemon"
+        );
+
+        let response_line = handle.join().unwrap();
+        let response: Response = serde_json::from_str(response_line.trim()).unwrap();
+        assert!(!response.ok);
+        assert!(response.message.contains("instance"));
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,6 +2,15 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::fallback::FallbackAction;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingFallbackState {
+    pub deadline: String,
+    pub action: FallbackAction,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CryoState {
@@ -28,6 +37,14 @@ pub struct CryoState {
     /// session updates it).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider_index: Option<usize>,
+
+    /// Identity token for the currently running daemon instance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+
+    /// Dead-man switch fallback that should survive daemon restarts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_fallback: Option<PendingFallbackState>,
 }
 
 pub fn state_path(dir: &Path) -> PathBuf {
@@ -51,6 +68,14 @@ pub fn load_state(path: &Path) -> Result<Option<CryoState>> {
     }
     let state: CryoState = serde_json::from_str(&contents)?;
     Ok(Some(state))
+}
+
+pub fn new_instance_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{:x}-{:x}", std::process::id(), nanos)
 }
 
 pub fn is_locked(state: &CryoState) -> bool {
@@ -120,6 +145,8 @@ mod tests {
             max_session_duration_override: None,
             last_report_time: None,
             provider_index: None,
+            instance_id: None,
+            pending_fallback: None,
         };
         assert!(!is_locked(&state), "Dead PID should not be locked");
     }
@@ -136,6 +163,8 @@ mod tests {
             max_session_duration_override: None,
             last_report_time: None,
             provider_index: None,
+            instance_id: None,
+            pending_fallback: None,
         };
         assert!(!is_locked(&state), "No PID should not be locked");
     }
@@ -152,6 +181,8 @@ mod tests {
             max_session_duration_override: None,
             last_report_time: None,
             provider_index: None,
+            instance_id: None,
+            pending_fallback: None,
         };
         assert!(is_locked(&state), "Own PID should be locked");
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -53,7 +53,17 @@ pub fn state_path(dir: &Path) -> PathBuf {
 
 pub fn save_state(path: &Path, state: &CryoState) -> Result<()> {
     let json = serde_json::to_string_pretty(state)?;
-    std::fs::write(path, json)?;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("state");
+    let tmp = path.with_file_name(format!(
+        ".{file_name}.tmp-{}-{nanos}",
+        std::process::id()
+    ));
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, path)?;
     Ok(())
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -118,11 +118,7 @@ async fn get_status(State(state): State<Arc<AppState>>) -> Json<Value> {
 
     let task = log::parse_latest_session_task(&log_file).ok().flatten();
 
-    // Fall back to parsing wake time from log if timer.json hasn't been updated yet
-    let effective_wake =
-        next_wake.or_else(|| log::parse_latest_session_wake(&log_file).ok().flatten());
-
-    let next_wake_rel = effective_wake.as_deref().and_then(|w| {
+    let next_wake_rel = next_wake.as_deref().and_then(|w| {
         let wake = chrono::NaiveDateTime::parse_from_str(w, "%Y-%m-%dT%H:%M").ok()?;
         let now = chrono::Local::now().naive_local();
         let diff_ms = (wake - now).num_milliseconds();
@@ -466,6 +462,39 @@ mod tests {
         assert!(
             next_wake.contains("2099-12-31T23:59"),
             "Status should show TODO-derived wake time, got: {next_wake}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_status_ignores_legacy_log_wake_without_todo() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let config = crate::config::CryoConfig::default();
+        let config_path = dir.path().join("cryo.toml");
+        crate::config::save_config(&config_path, &config).unwrap();
+
+        let log_path = dir.path().join("cryo.log");
+        std::fs::write(
+            &log_path,
+            "--- CRYO SESSION 1 | 2026-02-23T10:00:00Z ---\n\
+task: test\n\
+agent: opencode\n\
+inbox: 0 messages\n\
+[10:00:05] hibernate: wake=2099-12-31T23:59, exit=0, summary=\"legacy\"\n\
+--- CRYO END ---\n",
+        )
+        .unwrap();
+
+        let (tx, _rx) = tokio::sync::broadcast::channel::<SseEvent>(16);
+        let state = AppState {
+            project_dir: dir.path().to_path_buf(),
+            tx,
+        };
+        let resp = get_status(State(Arc::new(state))).await;
+        let status = &resp.0;
+        assert!(
+            status["next_wake"].is_null(),
+            "Status should ignore legacy log wake entries when todo.json has no pending wake"
         );
     }
 

--- a/templates/cryo.toml
+++ b/templates/cryo.toml
@@ -3,7 +3,7 @@
 # Agent command (e.g. "opencode", "claude", "codex")
 agent = "{{agent}}"
 
-# Max retry attempts on agent failure (0 = no retry)
+# Failed attempts before sending a retry alert (daemon keeps retrying)
 max_retries = 5
 
 # Session timeout in seconds (0 = no timeout)

--- a/templates/protocol.md
+++ b/templates/protocol.md
@@ -16,6 +16,8 @@ Execute these steps in order. **Do not skip or reorder steps.**
 ### Step 2: Work
 
 - Do the work described in your plan.
+- The only supported way to communicate with the human is through `cryo-agent send` and `cryo-agent reply`.
+- Do not use stdout/stderr as a conversation channel; they are diagnostic logs in `cryo-agent.log`.
 - Reply to any inbox messages: `cryo-agent reply "response text"`
 - Update TODOs as you go: `cryo-agent todo done <id>`
 
@@ -48,9 +50,16 @@ cryo-agent hibernate --summary "what I did, what's next"
 cryo-agent hibernate --complete --summary "All tasks finished"
 ```
 
-**Blocked or failed:**
+**Waiting on user or external input:**
 ```
-cryo-agent hibernate --exit 1 --summary "Blocked on X"
+cryo-agent reply "What you need from the human"
+cryo-agent todo add "Check for reply" --at <TIME>
+cryo-agent hibernate --summary "Waiting on user/external input"
+```
+
+**Failure (retryable only):**
+```
+cryo-agent hibernate --exit 1 --summary "Failure: why this session should retry"
 ```
 
 ## Wake Time Guidelines
@@ -82,6 +91,7 @@ cryo-agent time "+1 day"                      # Relative time computation
 
 - **TODO list drives your schedule.** The daemon wakes at the earliest pending TODO's `at` time.
 - **Inbox messages wake you early.** Humans can send messages. You'll see them in your prompt.
+- **Human communication goes through `cryo-agent`.** Use `send`/`reply`; stdout/stderr are logs only.
 - **Notes survive across sessions.** Use `cryo-agent note` liberally — it's your memory.
 - **No hibernate = crash.** If you exit without calling `cryo-agent hibernate`, the daemon retries with backoff.
 - **Delayed wakes happen.** If the machine was suspended, you'll see a system notice. Adjust accordingly.

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -41,6 +41,10 @@ fn test_build_prompt_contains_cli_reminders() {
     let prompt = build_prompt(&config);
     assert!(prompt.contains("cryo-agent hibernate"));
     assert!(prompt.contains("cryo-agent note"));
+    assert!(prompt.contains("cryo-agent send"));
+    assert!(prompt.contains("cryo-agent reply"));
+    assert!(prompt.contains("cryo-agent.log"));
+    assert!(prompt.contains("cryo-agent hibernate --exit 1"));
     assert!(prompt.contains("plan.md"));
 }
 
@@ -136,4 +140,16 @@ fn test_resolve_mock_agent() {
 fn test_mock_agent_program() {
     let program = cryochamber::agent::agent_program("mock").unwrap();
     assert_eq!(program, "sh");
+}
+
+#[test]
+fn test_build_command_claude_p_flag_is_idempotent() {
+    let cmd = cryochamber::agent::build_command("claude -p", "test prompt").unwrap();
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(args.iter().filter(|arg| arg.as_str() == "-p").count(), 1);
+    assert_eq!(args.last().map(String::as_str), Some("test prompt"));
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -681,6 +681,102 @@ fn test_session_logs_inbox_filenames() {
     assert!(log_content.contains("inbox: 1 messages"));
 }
 
+#[test]
+fn test_restart_respects_no_service_mode() {
+    let dir = tempfile::tempdir().unwrap();
+    init_dir(dir.path());
+
+    cmd()
+        .args(["start", "--agent", "/bin/sh -c 'sleep 30'"])
+        .env("CRYO_NO_SERVICE", "1")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let before = cryochamber::state::load_state(&dir.path().join("timer.json"))
+        .unwrap()
+        .and_then(|state| state.pid)
+        .expect("daemon should record a pid after start");
+
+    cmd()
+        .arg("restart")
+        .env("CRYO_NO_SERVICE", "1")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Restarted (background process)."));
+
+    let after = cryochamber::state::load_state(&dir.path().join("timer.json"))
+        .unwrap()
+        .and_then(|state| state.pid)
+        .expect("daemon should record a pid after restart");
+
+    assert_ne!(before, after, "restart should replace the running daemon");
+
+    let _ = cmd()
+        .arg("cancel")
+        .env("CRYO_NO_SERVICE", "1")
+        .current_dir(dir.path())
+        .output();
+}
+
+#[test]
+fn test_agent_note_rejects_stale_instance_id() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("plan.md"), "# Plan").unwrap();
+    init_dir(dir.path());
+
+    cmd()
+        .args(["start", "--agent", &mock_agent_cmd()])
+        .env("CRYO_AGENT_BIN", cryo_agent_bin_path())
+        .env("CRYO_NO_SERVICE", "1")
+        .env("MOCK_AGENT_COMPLETE", "false")
+        .env("MOCK_AGENT_WAKE", "2099-12-31T23:59")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if let Ok(log) = fs::read_to_string(dir.path().join("cryo.log")) {
+            if log.contains("session complete") {
+                break;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "daemon should finish the first session before stale instance validation"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    let timer_path = dir.path().join("timer.json");
+    let original_state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&timer_path).unwrap()).unwrap();
+    let mut state = original_state.clone();
+    state["instance_id"] = serde_json::Value::String("stale-instance".to_string());
+    fs::write(&timer_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    agent_cmd()
+        .args(["note", "hello from stale state"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("instance"));
+
+    fs::write(
+        &timer_path,
+        serde_json::to_string_pretty(&original_state).unwrap(),
+    )
+    .unwrap();
+
+    let _ = cmd()
+        .arg("cancel")
+        .env("CRYO_NO_SERVICE", "1")
+        .current_dir(dir.path())
+        .output();
+}
+
 // --- cryo-agent binary tests ---
 
 #[test]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -15,6 +15,21 @@ fn agent_cmd() -> Command {
     Command::cargo_bin("cryo-agent").unwrap()
 }
 
+fn wait_for_idle_daemon(dir: &std::path::Path, timeout: std::time::Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Ok(response) =
+            cryochamber::socket::send_request(dir, &cryochamber::socket::Request::Ping)
+        {
+            if response.ok && response.message == "pong" {
+                return true;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+    false
+}
+
 /// Run `cryo init` in a temp dir so tests that need `cryo start` have protocol files.
 fn init_dir(dir: &std::path::Path) {
     cmd().arg("init").current_dir(dir).assert().success();
@@ -749,6 +764,11 @@ fn test_agent_note_rejects_stale_instance_id() {
         );
         std::thread::sleep(std::time::Duration::from_millis(200));
     }
+
+    assert!(
+        wait_for_idle_daemon(dir.path(), std::time::Duration::from_secs(5)),
+        "daemon should return to the idle loop before stale instance validation"
+    );
 
     let timer_path = dir.path().join("timer.json");
     let original_state: serde_json::Value =

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -68,6 +68,8 @@ fn test_apply_overrides_all() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
 
     config.apply_overrides(&state);
@@ -97,6 +99,8 @@ fn test_apply_overrides_none_keeps_config() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
 
     config.apply_overrides(&state);
@@ -128,6 +132,8 @@ fn test_apply_overrides_partial() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
 
     config.apply_overrides(&state);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -57,6 +57,8 @@ fn test_state_roundtrip() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
     save_state(&state_path, &state).unwrap();
 

--- a/tests/message_tests.rs
+++ b/tests/message_tests.rs
@@ -179,19 +179,37 @@ fn test_empty_subject_uses_hash_disambiguator() {
 }
 
 #[test]
-fn test_empty_subject_same_content_same_hash() {
+fn test_identical_messages_do_not_overwrite_each_other() {
     let dir = tempfile::tempdir().unwrap();
-    // Same body and author at same timestamp — should produce same filename (overwrite is expected)
+    // Same body/author/timestamp should still produce distinct files.
     let msg1 = make_message("alice", "", "Same content", "2026-02-23T10:00:00");
     let msg2 = make_message("alice", "", "Same content", "2026-02-23T10:00:00");
 
     let path1 = write_message(dir.path(), "inbox", &msg1).unwrap();
     let path2 = write_message(dir.path(), "inbox", &msg2).unwrap();
 
-    assert_eq!(
+    assert_ne!(path1, path2, "Messages should not overwrite each other");
+
+    let inbox = read_inbox(dir.path()).unwrap();
+    assert_eq!(inbox.len(), 2);
+}
+
+#[test]
+fn test_non_empty_subject_same_second_does_not_overwrite() {
+    let dir = tempfile::tempdir().unwrap();
+    let msg1 = make_message("alice", "Status", "First update", "2026-02-23T10:00:00");
+    let msg2 = make_message("bob", "Status", "Second update", "2026-02-23T10:00:00");
+
+    let path1 = write_message(dir.path(), "inbox", &msg1).unwrap();
+    let path2 = write_message(dir.path(), "inbox", &msg2).unwrap();
+
+    assert_ne!(
         path1, path2,
-        "Identical messages should produce same filename"
+        "Messages with same subject should not collide"
     );
+
+    let inbox = read_inbox(dir.path()).unwrap();
+    assert_eq!(inbox.len(), 2);
 }
 
 #[test]

--- a/tests/mock_agent_tests.rs
+++ b/tests/mock_agent_tests.rs
@@ -423,6 +423,34 @@ fn test_mock_hibernate_then_crash() {
     cancel_and_wait(dir.path());
 }
 
+#[test]
+fn test_mock_hibernate_exit_code_retries() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_scenario(dir.path(), "hibernate-failed-then-succeed.sh");
+
+    cryo_bin()
+        .args(["start", "--agent", "mock", "--max-session-duration", "30"])
+        .env("CRYO_NO_SERVICE", "1")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(
+        wait_for_daemon_exit(dir.path(), Duration::from_secs(20)),
+        "Daemon should retry after nonzero hibernate exit code and then complete"
+    );
+
+    let log = fs::read_to_string(dir.path().join("cryo.log")).unwrap();
+    assert!(
+        log.contains("CRYO SESSION 2"),
+        "Nonzero hibernate exit code should trigger a retry session: {log}"
+    );
+    assert!(
+        log.contains("plan complete"),
+        "Retry scenario should eventually complete the plan: {log}"
+    );
+}
+
 // --- Provider rotation tests ---
 
 #[test]
@@ -809,6 +837,94 @@ fn test_fallback_cancelled_on_success() {
             );
         }
     }
+}
+
+#[test]
+fn test_pending_fallback_persists_across_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    setup_scenario(dir.path(), "alert-then-hibernate.sh");
+
+    cryo_bin()
+        .args(["start", "--agent", "mock"])
+        .env("CRYO_NO_SERVICE", "1")
+        .env("TEST_WAKE_AT", "2099-12-31T23:59")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut before_restart = None;
+    while std::time::Instant::now() < deadline {
+        if let Ok(content) = fs::read_to_string(dir.path().join("timer.json")) {
+            if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
+                if !state["pid"].is_null() && state.get("pending_fallback").is_some() {
+                    before_restart = Some(state);
+                    break;
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    let before_restart =
+        before_restart.expect("pending_fallback should be persisted after hibernate");
+    let before_instance = before_restart["instance_id"]
+        .as_str()
+        .expect("daemon should persist an instance_id")
+        .to_string();
+    assert_eq!(
+        before_restart["pending_fallback"]["action"]["action"],
+        "email"
+    );
+    assert_eq!(
+        before_restart["pending_fallback"]["action"]["target"],
+        "ops@test.com"
+    );
+    assert_eq!(
+        before_restart["pending_fallback"]["action"]["message"],
+        "Watchdog set"
+    );
+
+    cryo_bin()
+        .arg("restart")
+        .env("CRYO_NO_SERVICE", "1")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut after_restart = None;
+    while std::time::Instant::now() < deadline {
+        if let Ok(content) = fs::read_to_string(dir.path().join("timer.json")) {
+            if let Ok(state) = serde_json::from_str::<serde_json::Value>(&content) {
+                if !state["pid"].is_null() && state.get("pending_fallback").is_some() {
+                    let instance = state["instance_id"].as_str().unwrap_or_default();
+                    if instance != before_instance {
+                        after_restart = Some(state);
+                        break;
+                    }
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    let after_restart =
+        after_restart.expect("pending_fallback and fresh instance_id should survive restart");
+    assert_eq!(
+        after_restart["pending_fallback"]["action"]["action"],
+        "email"
+    );
+    assert_eq!(
+        after_restart["pending_fallback"]["action"]["target"],
+        "ops@test.com"
+    );
+    assert_eq!(
+        after_restart["pending_fallback"]["action"]["message"],
+        "Watchdog set"
+    );
+
+    cancel_and_wait(dir.path());
 }
 
 #[test]

--- a/tests/mock_agent_tests.rs
+++ b/tests/mock_agent_tests.rs
@@ -28,7 +28,7 @@ fn setup_scenario(dir: &std::path::Path, scenario_name: &str) {
 
 /// Wait for the daemon to exit by polling timer.json for pid=null.
 /// Returns true if daemon exited within the timeout.
-/// Treats missing or unparseable timer.json as "exited" (cryo cancel removes the file).
+/// Treats missing timer.json as "exited" (some commands remove the file).
 fn wait_for_daemon_exit(dir: &std::path::Path, timeout: Duration) -> bool {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
@@ -40,7 +40,6 @@ fn wait_for_daemon_exit(dir: &std::path::Path, timeout: Duration) -> bool {
         match fs::read_to_string(&timer_path) {
             Ok(content) => match serde_json::from_str::<serde_json::Value>(&content) {
                 Ok(state) if state["pid"].is_null() => return true,
-                Err(_) => return true,
                 _ => {}
             },
             Err(_) => return true,

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -22,6 +22,22 @@ fn test_protocol_content_contains_rules() {
 }
 
 #[test]
+fn test_protocol_user_channel_is_cryo_agent_only() {
+    let content = protocol::PROTOCOL_CONTENT;
+    assert!(content.contains("only supported way to communicate with the human"));
+    assert!(content.contains("stdout/stderr"));
+    assert!(content.contains("cryo-agent send"));
+    assert!(content.contains("cryo-agent reply"));
+}
+
+#[test]
+fn test_protocol_no_blocked_hibernate_mode() {
+    let content = protocol::PROTOCOL_CONTENT;
+    assert!(!content.contains("Blocked or failed"));
+    assert!(!content.contains("Blocked on X"));
+}
+
+#[test]
 fn test_protocol_filename_claude() {
     assert_eq!(protocol::protocol_filename("claude"), "CLAUDE.md");
     assert_eq!(protocol::protocol_filename("claude-code"), "CLAUDE.md");

--- a/tests/scenarios/alert-then-hibernate.sh
+++ b/tests/scenarios/alert-then-hibernate.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cryo-agent alert email ops@test.com "Watchdog set"
+cryo-agent todo add "scheduled wake" --at "$TEST_WAKE_AT"
+cryo-agent hibernate --summary "Waiting for next wake"

--- a/tests/scenarios/hibernate-failed-then-succeed.sh
+++ b/tests/scenarios/hibernate-failed-then-succeed.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Session 1 reports a retryable failure via `cryo-agent hibernate --exit 1`.
+# Session 2 completes successfully after the daemon retries.
+
+COUNTER_FILE=".mock-hibernate-fail-count"
+
+if [ -f "$COUNTER_FILE" ]; then
+    COUNT=$(cat "$COUNTER_FILE")
+else
+    COUNT=0
+fi
+
+COUNT=$((COUNT + 1))
+echo "$COUNT" > "$COUNTER_FILE"
+
+if [ "$COUNT" -ge 2 ]; then
+    cryo-agent hibernate --complete --summary "Recovered on attempt $COUNT"
+else
+    cryo-agent hibernate --exit 1 --summary "Retryable failure on attempt $COUNT"
+fi

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -16,6 +16,8 @@ fn test_save_and_load_state() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
 
     save_state(&state_path, &state).unwrap();
@@ -49,6 +51,8 @@ fn test_lock_mechanism() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
     save_state(&state_path, &state).unwrap();
 
@@ -71,6 +75,8 @@ fn test_is_locked_dead_process() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
     assert!(!is_locked(&state));
 }
@@ -88,6 +94,8 @@ fn test_is_locked_no_pid() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
     assert!(!is_locked(&state));
 }
@@ -141,6 +149,8 @@ fn test_override_fields_roundtrip() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
     save_state(&state_path, &state).unwrap();
     let loaded = load_state(&state_path).unwrap().unwrap();
@@ -164,6 +174,8 @@ fn test_none_overrides_not_serialized() {
 
         last_report_time: None,
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
     save_state(&state_path, &state).unwrap();
     let json = std::fs::read_to_string(&state_path).unwrap();
@@ -188,6 +200,8 @@ fn test_last_report_time_roundtrip() {
 
         last_report_time: Some("2026-02-28T09:00:00".to_string()),
         provider_index: None,
+        instance_id: None,
+        pending_fallback: None,
     };
     save_state(&state_path, &state).unwrap();
     let loaded = load_state(&state_path).unwrap().unwrap();
@@ -215,6 +229,8 @@ fn test_provider_index_roundtrip() {
 
         last_report_time: None,
         provider_index: Some(2),
+        instance_id: None,
+        pending_fallback: None,
     };
     save_state(&state_path, &state).unwrap();
     let loaded = load_state(&state_path).unwrap().unwrap();


### PR DESCRIPTION
## Summary
- harden daemon lifecycle handling around state identity, pending fallback persistence, and startup recovery
- extract testable seams for idle waiting, active session control, side effects, and startup policy in the daemon loop
- update protocol/docs and add regression coverage for retry, TODO-driven wake, message naming, and runtime scenarios

## Test Plan
- cargo fmt --all
- cargo test
- cargo clippy --all-targets -- -D warnings