### PR TITLE
chore: drop notify-rust, route all alerts through outbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ make release V=x.y.z # tag and push a release (triggers CI publish to crates.io)
 | `fallback` | Dead-man switch: writes alerts to `messages/outbox/` for external delivery. |
 | `channel` | Channel abstraction. Submodules: `file` (local inbox/outbox), `github` (Discussions via GraphQL), `zulip` (Zulip REST API). |
 | `registry` | PID file registry for tracking running daemons. Uses `$XDG_RUNTIME_DIR/cryo/` (fallback `~/.cryo/daemons/`). Auto-cleans stale entries. |
-| `report` | Periodic session summary reports. Parses log, counts sessions/failures, sends desktop notification via notify-rust. |
+| `report` | Periodic session summary reports. Parses log, counts sessions/failures, writes summary to `messages/outbox/` for sync delivery. |
 | `service` | OS service management: install/uninstall launchd (macOS) or systemd (Linux) user services. Used by `cryo start` and `cryo-gh sync` for reboot-persistent daemons. `CRYO_NO_SERVICE=1` disables (falls back to direct spawn). |
 | `gh_sync` | GitHub Discussion sync state persistence (`gh-sync.json`). |
 | `todo` | Per-project TODO list persistence (`todo.json`). `TodoItem`/`TodoList` structs, load/save, add/done/remove. Mutated through daemon IPC so scheduling changes are serialized with the session lifecycle. |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ dirs = "6.0.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-notify-rust = "4"
 ureq = "3"
 
 [dev-dependencies]

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -12,6 +12,13 @@ watch_inbox = true        # Watch inbox for reactive wake
 # Web UI host and port (for `cryo web`)
 # web_host = "127.0.0.1"
 # web_port = 3945
+
+# Fallback alert method when the dead-man switch fires
+# fallback_alert = "outbox"  # "outbox" writes to messages/outbox/; "none" disables alerts
+
+# Periodic status report written to messages/outbox/
+# report_time = "09:00"     # HH:MM local time
+# report_interval = 24      # hours between reports; 0 disables reports
 ```
 
 ## Fields
@@ -24,6 +31,9 @@ watch_inbox = true        # Watch inbox for reactive wake
 | `watch_inbox` | `true` | Watch `messages/inbox/` for new files and wake immediately. |
 | `web_host` | `"127.0.0.1"` | Host for `cryo web` to listen on. Use `"0.0.0.0"` for remote access only behind an authenticated, TLS-terminating proxy. |
 | `web_port` | `3945` | Port for `cryo web` to listen on. |
+| `fallback_alert` | `"outbox"` | Fallback alert behavior. `"outbox"` writes alerts to `messages/outbox/`; `"none"` suppresses fallback alert files. Legacy `"notify"` is accepted and treated as `"outbox"`. |
+| `report_time` | `"09:00"` | Local wall-clock time for periodic status reports, formatted as `HH:MM`. |
+| `report_interval` | `0` | Hours between periodic reports. `0` disables reports; common values are `24` for daily and `168` for weekly. Reports are written to `messages/outbox/`. |
 
 ## CLI Overrides
 

--- a/skills/make-plan/SKILL.md
+++ b/skills/make-plan/SKILL.md
@@ -80,7 +80,7 @@ How should the agent communicate with the user?
 
 ### Q10. Periodic reports
 
-Want daily/hourly health summaries as desktop notifications?
+Want daily/hourly health summaries written to `messages/outbox/` (delivered via any configured sync channel)?
 - If yes: set `report_time` (e.g. "09:00") and `report_interval` (hours, e.g. 24 for daily).
 - If no: skip (disabled by default).
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,8 @@ pub struct CryoConfig {
     #[serde(default = "default_web_port")]
     pub web_port: u16,
 
-    /// Fallback alert method: "notify" (desktop popup), "outbox" (file only), "none"
+    /// Fallback alert method: "outbox" (write to messages/outbox/) or "none" (suppress).
+    /// Legacy "notify" is accepted and treated as "outbox".
     #[serde(default = "default_fallback_alert")]
     pub fallback_alert: String,
 
@@ -105,7 +106,7 @@ fn default_web_port() -> u16 {
 }
 
 fn default_fallback_alert() -> String {
-    "notify".to_string()
+    "outbox".to_string()
 }
 
 fn default_report_time() -> String {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1601,8 +1601,10 @@ impl Daemon {
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("unknown");
-                if let Err(e) = crate::report::send_report_notification(&summary, project_name) {
-                    eprintln!("Daemon: report notification failed: {e}");
+                if let Err(e) =
+                    crate::report::write_report_to_outbox(&self.dir, &summary, project_name)
+                {
+                    eprintln!("Daemon: report outbox write failed: {e}");
                 }
                 eprintln!(
                     "Daemon: report sent ({} sessions, {} failed)",

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -30,13 +30,14 @@ impl FallbackAction {
         self.action == "webhook"
     }
 
-    /// Write the fallback alert to messages/outbox/ and optionally dispatch
-    /// a system notification based on the configured alert method.
+    /// Write the fallback alert to `messages/outbox/` for delivery by whatever
+    /// reads it (sync channels, external watchers, the user tailing files).
     ///
-    /// `alert_method` controls the action:
-    /// - `"notify"`: desktop notification + outbox file
-    /// - `"outbox"`: outbox file only (no popup)
-    /// - `"none"`: disable fallback alerts entirely
+    /// `alert_method` controls behavior:
+    /// - `"outbox"` (default): write the alert file
+    /// - `"none"`: suppress — no file written
+    ///
+    /// Legacy `"notify"` is accepted and treated as `"outbox"` for back-compat.
     pub fn execute(&self, work_dir: &Path, alert_method: &str) -> Result<()> {
         if alert_method == "none" {
             eprintln!("Fallback: alert suppressed (fallback_alert = \"none\")");
@@ -62,33 +63,6 @@ impl FallbackAction {
             path.strip_prefix(work_dir).unwrap_or(&path).display()
         );
 
-        if alert_method == "notify" {
-            if let Err(e) = self.send_notification() {
-                eprintln!("Fallback: desktop notification failed: {e}");
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Send a desktop notification via notify-rust.
-    fn send_notification(&self) -> Result<()> {
-        let mut notification = notify_rust::Notification::new();
-        notification
-            .summary(&format!("Cryochamber Alert: {}", self.action))
-            .body(&self.message);
-        // Platform-specific alert emphasis
-        #[cfg(target_os = "linux")]
-        {
-            notification.urgency(notify_rust::Urgency::Critical);
-            notification.timeout(notify_rust::Timeout::Never);
-        }
-        #[cfg(target_os = "macos")]
-        {
-            notification.subtitle("Dead-man switch fired");
-            notification.sound_name("Sosumi");
-        }
-        notification.show()?;
         Ok(())
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
-use chrono::{NaiveDateTime, NaiveTime, Utc};
+use chrono::{Local, NaiveDateTime, NaiveTime, Utc};
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use crate::log::{self, SessionOutcome};
+use crate::message::{self, Message};
 
 /// Aggregated report for a time period.
 #[derive(Debug, Clone)]
@@ -33,8 +35,14 @@ pub fn generate_report(log_path: &Path, since: NaiveDateTime) -> Result<ReportSu
     })
 }
 
-/// Send a desktop notification with the report summary.
-pub fn send_report_notification(summary: &ReportSummary, project_name: &str) -> Result<()> {
+/// Write the periodic report to `messages/outbox/` so it flows through whichever
+/// sync channel the user has configured (Zulip, GitHub Discussions, external
+/// watcher, etc.). Returns the path of the written message.
+pub fn write_report_to_outbox(
+    work_dir: &Path,
+    summary: &ReportSummary,
+    project_name: &str,
+) -> Result<std::path::PathBuf> {
     let period_label = match summary.period_hours {
         0..=23 => format!("{}h", summary.period_hours),
         24..=167 => format!("{}d", summary.period_hours / 24),
@@ -44,22 +52,26 @@ pub fn send_report_notification(summary: &ReportSummary, project_name: &str) -> 
         "Last {}: {} sessions, {} failed",
         period_label, summary.total_sessions, summary.failed_sessions,
     );
-    let mut notification = notify_rust::Notification::new();
-    notification
-        .summary(&format!("Cryochamber Report: {}", project_name))
-        .body(&body);
-    #[cfg(target_os = "linux")]
-    {
-        notification.urgency(notify_rust::Urgency::Normal);
-        notification.timeout(notify_rust::Timeout::Milliseconds(10000));
-    }
-    #[cfg(target_os = "macos")]
-    {
-        notification.subtitle("Periodic report");
-        notification.sound_name("Tink");
-    }
-    notification.show()?;
-    Ok(())
+
+    message::ensure_dirs(work_dir)?;
+    let msg = Message {
+        from: "cryochamber".to_string(),
+        subject: format!("Cryochamber Report: {}", project_name),
+        body,
+        timestamp: Local::now().naive_local(),
+        metadata: BTreeMap::from([
+            (
+                "total_sessions".to_string(),
+                summary.total_sessions.to_string(),
+            ),
+            (
+                "failed_sessions".to_string(),
+                summary.failed_sessions.to_string(),
+            ),
+            ("period_hours".to_string(), summary.period_hours.to_string()),
+        ]),
+    };
+    message::write_message(work_dir, "outbox", &msg)
 }
 
 /// Compute the next report time based on config and last report.
@@ -105,7 +117,7 @@ pub fn compute_next_report_time(
 mod tests {
     use super::*;
     use crate::log::EventLogger;
-    use chrono::{Local, Timelike};
+    use chrono::Timelike;
 
     #[test]
     fn test_generate_report_counts() {
@@ -154,6 +166,54 @@ mod tests {
         let report = generate_report(&log_path, since).unwrap();
         assert_eq!(report.total_sessions, 0);
         assert_eq!(report.failed_sessions, 0);
+    }
+
+    #[test]
+    fn test_write_report_to_outbox_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let summary = ReportSummary {
+            total_sessions: 8,
+            failed_sessions: 1,
+            period_hours: 24,
+        };
+        let path = write_report_to_outbox(dir.path(), &summary, "my-project").unwrap();
+
+        assert!(path.exists(), "outbox file should exist");
+        assert!(
+            path.starts_with(dir.path().join("messages").join("outbox")),
+            "file should be in messages/outbox/: {}",
+            path.display()
+        );
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("Cryochamber Report: my-project"),
+            "subject missing from outbox file: {content}"
+        );
+        assert!(
+            content.contains("Last 1d: 8 sessions, 1 failed"),
+            "body missing from outbox file: {content}"
+        );
+    }
+
+    #[test]
+    fn test_write_report_to_outbox_period_labels() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let hourly = ReportSummary {
+            total_sessions: 1,
+            failed_sessions: 0,
+            period_hours: 3,
+        };
+        let p = write_report_to_outbox(dir.path(), &hourly, "p").unwrap();
+        assert!(std::fs::read_to_string(&p).unwrap().contains("Last 3h:"));
+
+        let weekly = ReportSummary {
+            total_sessions: 50,
+            failed_sessions: 2,
+            period_hours: 168,
+        };
+        let p = write_report_to_outbox(dir.path(), &weekly, "p").unwrap();
+        assert!(std::fs::read_to_string(&p).unwrap().contains("Last 1w:"));
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -57,11 +57,11 @@ pub fn save_state(path: &Path, state: &CryoState) -> Result<()> {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or("state");
-    let tmp = path.with_file_name(format!(
-        ".{file_name}.tmp-{}-{nanos}",
-        std::process::id()
-    ));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("state");
+    let tmp = path.with_file_name(format!(".{file_name}.tmp-{}-{nanos}", std::process::id()));
     std::fs::write(&tmp, json)?;
     std::fs::rename(&tmp, path)?;
     Ok(())

--- a/templates/cryo.toml
+++ b/templates/cryo.toml
@@ -17,12 +17,11 @@ watch_inbox = true
 # web_port = 3945
 
 # Fallback alert method when dead-man switch fires:
-#   "notify" = desktop notification popup (default)
-#   "outbox" = outbox file only (no popup)
+#   "outbox" = write alert to messages/outbox/ (default; delivered by any sync channel)
 #   "none"   = disable fallback alerts entirely
-# fallback_alert = "notify"
+# fallback_alert = "outbox"
 
-# Periodic status report:
+# Periodic status report (written to messages/outbox/ for sync delivery):
 #   report_time = "09:00" (HH:MM local time)
 #   report_interval = 24 (hours between reports; 0 = disabled)
 # report_time = "09:00"

--- a/tests/mock_agent_tests.rs
+++ b/tests/mock_agent_tests.rs
@@ -682,7 +682,7 @@ fn test_fallback_fires_on_deadline() {
 
     let config = fs::read_to_string(dir.path().join("cryo.toml")).unwrap();
     let config = config.replace("max_retries = 5", "max_retries = 1");
-    // fallback_alert is commented out in the default template (# fallback_alert = "notify"),
+    // fallback_alert is commented out in the default template (# fallback_alert = "outbox"),
     // so we always append the uncommented setting. TOML uses the last occurrence.
     let config = format!("{config}\nfallback_alert = \"outbox\"\n");
     fs::write(dir.path().join("cryo.toml"), config).unwrap();
@@ -742,8 +742,7 @@ fn test_fallback_suppressed_when_none() {
 
     let config = fs::read_to_string(dir.path().join("cryo.toml")).unwrap();
     let config = config.replace("max_retries = 5", "max_retries = 1");
-    // fallback_alert is commented out in the default template (# fallback_alert = "notify"),
-    // so we always append the uncommented setting.
+    // fallback_alert is commented out in the default template, so append to override.
     let config = format!("{config}\nfallback_alert = \"none\"\n");
     fs::write(dir.path().join("cryo.toml"), config).unwrap();
 


### PR DESCRIPTION
## Summary

- Remove the `notify-rust` dependency and the desktop-popup path from both fallback alerts and periodic reports.
- Alerts now flow exclusively through `messages/outbox/`, which the configured sync channel (Zulip, GitHub Discussions, or any external watcher) delivers.
- Default `fallback_alert` changes from `"notify"` to `"outbox"`. Legacy `"notify"` is still accepted and treated as `"outbox"` for back-compat.

## Why

Cryochamber's value proposition is *unattended long-running agents* — typically deployed on headless servers, cloud VPSes, or home labs where nobody sees a desktop popup. The outbox is already the canonical delivery path; `notify-rust` was a vestige from early local-only days. Unifying on the outbox also means the feature works identically whether the user has Zulip, GitHub Discussions, a custom file watcher, or nothing at all.

The periodic report (`report_interval > 0`) previously only fired a desktop popup — it never wrote to the outbox. This PR fixes that gap: reports now go to `messages/outbox/` like everything else.

## Changes

- `src/fallback.rs`: delete `send_notification()`; `execute()` writes outbox only.
- `src/report.rs`: replace `send_report_notification()` with `write_report_to_outbox()`; add unit tests.
- `src/daemon.rs`: update `send_periodic_report` to use the new outbox writer.
- `src/config.rs`: change default `fallback_alert` to `"outbox"`; update docstring.
- `templates/cryo.toml`: update comment to list only `"outbox"` | `"none"`.
- `Cargo.toml`: drop `notify-rust = "4"`.
- Docs (`CLAUDE.md`, `skills/make-plan/SKILL.md`): reflect new behavior.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — all 127 lib + integration tests pass
- [x] `cargo tree -i notify-rust` confirms dep fully removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)