### PR TITLE
feat: differentiate daemon stand-in messages by hibernate state

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -230,21 +230,20 @@ struct EventLoopMutations<'a> {
     next_wake: &'a mut Option<NaiveDateTime>,
 }
 
-fn daemon_unanswered_reply_text(message_count: usize) -> String {
-    let (noun, verb) = if message_count == 1 {
-        ("message", "is")
+fn daemon_unanswered_reply_text(clean_hibernate: bool) -> &'static str {
+    if clean_hibernate {
+        "(daemon: agent hibernated without replying)"
     } else {
-        ("messages", "are")
-    };
-    format!(
-        "I received {message_count} {noun}, but the agent did not send a reply before the session ended. \
-         The daemon is replying so your {noun} {verb} not left unanswered."
-    )
+        "(daemon: agent crashed before replying)"
+    }
 }
 
-fn daemon_missing_outbound_text() -> &'static str {
-    "The agent completed this session without sending an outbox message. \
-     The daemon is sending this status so every agent run has a visible message."
+fn daemon_missing_outbound_text(clean_hibernate: bool) -> &'static str {
+    if clean_hibernate {
+        "(daemon: agent hibernated without sending anything)"
+    } else {
+        "(daemon: agent crashed before sending)"
+    }
 }
 
 fn ipc_protocol_response(protocol_version: u32) -> crate::socket::Response {
@@ -1091,12 +1090,13 @@ impl Daemon {
         effects: &mut impl SessionEffects,
         logger: &mut crate::log::EventLogger,
         inbox_state: &mut SessionInboxState,
+        clean_hibernate: bool,
     ) {
         let mut daemon_wrote_reply = false;
         let message_count = inbox_state.claimed_message_count();
         if message_count > 0 {
-            let text = daemon_unanswered_reply_text(message_count);
-            match effects.write_reply(ReplyAuthor::Daemon, &text, self.clock.local_now(), false) {
+            let text = daemon_unanswered_reply_text(clean_hibernate);
+            match effects.write_reply(ReplyAuthor::Daemon, text, self.clock.local_now(), false) {
                 Ok(()) => {
                     if let Err(e) = logger.log_event(&format!(
                         "daemon reply: {} unanswered inbox message{} [{}]",
@@ -1123,7 +1123,7 @@ impl Daemon {
         if message_count == 0 && !inbox_state.has_agent_outbound_message() && !daemon_wrote_reply {
             match effects.write_reply(
                 ReplyAuthor::Daemon,
-                daemon_missing_outbound_text(),
+                daemon_missing_outbound_text(clean_hibernate),
                 self.clock.local_now(),
                 false,
             ) {
@@ -1168,11 +1168,17 @@ impl Daemon {
         loop {
             if self.shutdown.load(Ordering::Relaxed) {
                 runtime.terminate();
+                let clean_hibernate = hibernate_outcome.is_some();
                 let decision = resolve_interrupted_session(
                     SessionInterruption::Shutdown,
                     hibernate_outcome.take(),
                 );
-                self.finalize_human_replies(effects, &mut logger, &mut inbox_state);
+                self.finalize_human_replies(
+                    effects,
+                    &mut logger,
+                    &mut inbox_state,
+                    clean_hibernate,
+                );
                 logger.finish(decision.finish_reason)?;
                 return Ok(decision.outcome);
             }
@@ -1184,11 +1190,17 @@ impl Daemon {
                         context.timeout_secs
                     );
                     runtime.terminate();
+                    let clean_hibernate = hibernate_outcome.is_some();
                     let decision = resolve_interrupted_session(
                         SessionInterruption::Timeout,
                         hibernate_outcome.take(),
                     );
-                    self.finalize_human_replies(effects, &mut logger, &mut inbox_state);
+                    self.finalize_human_replies(
+                        effects,
+                        &mut logger,
+                        &mut inbox_state,
+                        clean_hibernate,
+                    );
                     logger.finish(decision.finish_reason)?;
                     return Ok(decision.outcome);
                 }
@@ -1206,7 +1218,13 @@ impl Daemon {
                             inbox_state: &mut inbox_state,
                         },
                     ) {
-                        self.finalize_human_replies(effects, &mut logger, &mut inbox_state);
+                        let clean_hibernate = hibernate_outcome.is_some();
+                        self.finalize_human_replies(
+                            effects,
+                            &mut logger,
+                            &mut inbox_state,
+                            clean_hibernate,
+                        );
                         logger.finish(&format!("error handling agent request: {e}"))?;
                         return Err(e);
                     }
@@ -1231,6 +1249,7 @@ impl Daemon {
                             .unwrap_or_else(|| "signal".into())
                     ))?;
 
+                    let clean_hibernate = hibernate_outcome.is_some();
                     let decision = resolve_child_exit(hibernate_outcome.take(), elapsed);
                     if decision.quick_exit {
                         let elapsed_s = format!("{:.1}s", elapsed.as_secs_f32());
@@ -1244,13 +1263,24 @@ impl Daemon {
                             "quick exit detected ({elapsed_s} without hibernate)"
                         ))?;
                     }
-                    self.finalize_human_replies(effects, &mut logger, &mut inbox_state);
+                    self.finalize_human_replies(
+                        effects,
+                        &mut logger,
+                        &mut inbox_state,
+                        clean_hibernate,
+                    );
                     logger.finish(decision.finish_reason)?;
                     return Ok(decision.outcome);
                 }
                 Ok(None) => {}
                 Err(e) => {
-                    self.finalize_human_replies(effects, &mut logger, &mut inbox_state);
+                    let clean_hibernate = hibernate_outcome.is_some();
+                    self.finalize_human_replies(
+                        effects,
+                        &mut logger,
+                        &mut inbox_state,
+                        clean_hibernate,
+                    );
                     logger.finish(&format!("error checking agent: {e}"))?;
                     return Err(e.into());
                 }

--- a/src/unit_tests/daemon.rs
+++ b/src/unit_tests/daemon.rs
@@ -1379,7 +1379,7 @@ fn test_drive_active_session_writes_daemon_status_without_outbound_message() {
     assert!(
         effects.replies[0]
             .1
-            .contains("without sending an outbox message"),
+            .contains("daemon: agent hibernated without sending anything"),
         "daemon status should explain why it was sent: {:?}",
         effects.replies
     );
@@ -1493,7 +1493,7 @@ fn test_drive_active_session_unreceived_inbox_only_gets_daemon_status() {
     assert!(
         effects.replies[0]
             .1
-            .contains("without sending an outbox message"),
+            .contains("daemon: agent hibernated without sending anything"),
         "without a claimed inbox batch, the daemon should only send its generic status: {:?}",
         effects.replies
     );
@@ -1890,7 +1890,7 @@ fn test_drive_active_session_receive_request_invokes_effect_and_returns_body() {
     assert!(
         effects.replies[0]
             .1
-            .contains("the agent did not send a reply"),
+            .contains("daemon: agent hibernated without replying"),
         "daemon fallback reply should still be written after receive/archive: {:?}",
         effects.replies
     );
@@ -1964,7 +1964,7 @@ fn test_drive_active_session_dialog_request_returns_transcript_and_preserves_fal
     assert!(
         effects.replies[0]
             .1
-            .contains("the agent did not send a reply"),
+            .contains("daemon: agent hibernated without replying"),
         "dialog should preserve the fallback reply obligation: {:?}",
         effects.replies
     );
@@ -2026,7 +2026,7 @@ fn test_drive_active_session_dialog_failure_after_claim_still_triggers_fallback(
     assert!(
         effects.replies[0]
             .1
-            .contains("the agent did not send a reply"),
+            .contains("daemon: agent hibernated without replying"),
         "a failed dialog after claim must still preserve fallback reply behavior: {:?}",
         effects.replies
     );

--- a/src/unit_tests/daemon.rs
+++ b/src/unit_tests/daemon.rs
@@ -1337,6 +1337,15 @@ fn test_drive_active_session_quick_exit_without_hibernate() {
     );
     assert!(!runtime.terminated());
     assert!(runtime.responses().is_empty());
+    assert_eq!(effects.replies.len(), 1);
+    assert_eq!(effects.replies[0].0, ReplyAuthor::Daemon);
+    assert!(
+        effects.replies[0]
+            .1
+            .contains("daemon: agent crashed before sending"),
+        "daemon status should explain the crash path: {:?}",
+        effects.replies
+    );
 }
 
 #[test]
@@ -1892,6 +1901,53 @@ fn test_drive_active_session_receive_request_invokes_effect_and_returns_body() {
             .1
             .contains("daemon: agent hibernated without replying"),
         "daemon fallback reply should still be written after receive/archive: {:?}",
+        effects.replies
+    );
+}
+
+#[test]
+fn test_drive_active_session_receive_then_crash_uses_crash_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    crate::message::ensure_dirs(dir.path()).unwrap();
+    let now = chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+        .unwrap()
+        .and_hms_opt(12, 0, 0)
+        .unwrap();
+    let clock = Arc::new(TestClock::new(now));
+    let daemon = Daemon::new_with_clock(dir.path().to_path_buf(), clock.clone());
+    let cryo_state = test_cryo_state();
+
+    let mut runtime = FakeSessionRuntime::new(
+        vec![Ok(Some(crate::socket::Request::Receive))],
+        vec![Ok(None), Ok(Some(ChildExitStatus { code: Some(1) }))],
+    );
+    let mut effects = FakeSessionEffects::new();
+    effects.push_inbox_message("msg-1.md", "Archive me");
+
+    let outcome = daemon
+        .drive_active_session(
+            &mut runtime,
+            &mut effects,
+            test_session_context(&cryo_state, 60, clock.monotonic_now()),
+            begin_test_logger(dir.path()),
+        )
+        .unwrap();
+
+    assert_eq!(
+        outcome,
+        SessionLoopOutcome::ValidationFailed { quick_exit: true }
+    );
+    assert_eq!(runtime.responses().len(), 1);
+    assert!(runtime.responses()[0].0);
+    assert!(runtime.responses()[0].1.contains("--- msg-1.md ---"));
+    assert!(effects.inbox_messages.is_empty());
+    assert_eq!(effects.replies.len(), 1);
+    assert_eq!(effects.replies[0].0, ReplyAuthor::Daemon);
+    assert!(
+        effects.replies[0]
+            .1
+            .contains("daemon: agent crashed before replying"),
+        "daemon fallback reply should name the crash path: {:?}",
         effects.replies
     );
 }

--- a/tests/mock_agent_tests.rs
+++ b/tests/mock_agent_tests.rs
@@ -724,7 +724,7 @@ fn test_unreceived_queued_inbox_gets_daemon_status_only() {
         outbox[0]
             .1
             .body
-            .contains("without sending an outbox message"),
+            .contains("hibernated without sending anything"),
         "without receive, the daemon should only emit its generic session status: {:?}",
         outbox[0].1.body
     );


### PR DESCRIPTION
## Summary

- The daemon writes a stand-in outbox message when an agent claims an inbox batch but never replies, or when an agent finishes a session without sending anything. Previously each case used a single verbose two-sentence string that conflated clean hibernate with crash.
- The daemon already knows whether the agent called `cryo-agent hibernate` (`hibernate_outcome` is `Some` at the finalize call site). Now the stand-in text reflects it.
- Four short, mutually-distinct messages instead of two verbose ones:
  - `(daemon: agent hibernated without replying)` — claimed inbox batch, no reply, clean hibernate
  - `(daemon: agent crashed before replying)` — claimed inbox batch, no reply, no hibernate
  - `(daemon: agent hibernated without sending anything)` — no inbox claimed, no message, clean hibernate
  - `(daemon: agent crashed before sending)` — no inbox claimed, no message, no hibernate
- The two text helpers now take `clean_hibernate: bool`; the value is `hibernate_outcome.is_some()` captured at each call site before `.take()`. No new struct fields needed.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib daemon::` (105 passed)
- [x] `cargo test --test mock_agent_tests` (21 passed)
- [x] Updated substring assertions in `src/unit_tests/daemon.rs` and `tests/mock_agent_tests.rs` to match the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)