### PR TITLE
fix(daemon): reap the agent's whole process group on session timeout/shutdown (#56)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -243,8 +243,40 @@ pub fn spawn_agent(
         cmd.envs(provider_env);
     }
 
+    // Put the agent in its own process group (pgid == child pid) so the daemon can
+    // reap the whole subtree on timeout/shutdown, not just the direct child. Without
+    // this, a wrapper-script `agent` (e.g. run-agent.sh -> claude -> ssh ...) leaks
+    // the real CLI and its grandchildren when a session is terminated.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+
     let child = cmd
         .spawn()
         .map_err(|e| anyhow::anyhow!("Failed to spawn agent: {e}"))?;
     Ok(child)
+}
+
+#[cfg(all(test, unix))]
+mod process_group_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// A spawned agent must be its own process-group leader (pgid == its pid) so the
+    /// daemon can reap the whole subtree via `kill(-pgid)` on timeout/shutdown.
+    #[test]
+    fn spawned_agent_is_process_group_leader() {
+        let mut child = spawn_agent("sleep", "30", None, &HashMap::new())
+            .expect("spawn sleep agent");
+        let pid = child.id() as i32;
+
+        let pgid = unsafe { libc::getpgid(pid) };
+        // Clean up before asserting so the sleep never lingers if the assert fails.
+        assert!(crate::process::send_signal_group(pid as u32, libc::SIGKILL));
+        let _ = child.wait();
+
+        assert_eq!(pgid, pid, "agent should lead its own process group (pgid == pid)");
+    }
 }

--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::config::CryoConfig;
-use crate::process::send_signal;
+use crate::process::{send_signal, send_signal_group};
 use crate::state::CryoState;
 
 use super::effects::FsSessionEffects;
@@ -252,9 +252,15 @@ fn display_source_path(chamber_dir: &Path, source: &Path) -> String {
 
 /// Gracefully terminate a child process: SIGTERM, wait 2s, SIGKILL if needed.
 fn terminate_child(child: &mut std::process::Child, pid: u32, clock: &dyn Clock) {
+    // Signal the agent's whole process group (it is spawned as a group leader), not
+    // just the direct child, so wrapper-script -> CLI -> subprocess trees are fully
+    // reaped. Also signal the bare PID as a fallback in case the agent could not be
+    // placed in its own group.
+    send_signal_group(pid, libc::SIGTERM);
     send_signal(pid, libc::SIGTERM);
     clock.sleep(Duration::from_secs(2));
     if child.try_wait().ok().flatten().is_none() {
+        send_signal_group(pid, libc::SIGKILL);
         send_signal(pid, libc::SIGKILL);
     }
     let _ = child.wait();

--- a/src/process.rs
+++ b/src/process.rs
@@ -14,6 +14,21 @@ pub fn send_signal(pid: u32, signal: i32) -> bool {
     }
 }
 
+/// Send a signal to the entire process group led by `pgid` (negative-PID `kill`).
+/// Agents are spawned as their own group leader (pgid == the agent's pid), so this
+/// reaps the whole subtree — the wrapper script, the real CLI it launches, and any
+/// grandchildren it spawned. Returns true if delivered, false on failure.
+pub fn send_signal_group(pgid: u32, signal: i32) -> bool {
+    let ret = unsafe { libc::kill(-(pgid as i32), signal) };
+    if ret != 0 {
+        let err = std::io::Error::last_os_error();
+        eprintln!("Warning: failed to send signal {signal} to process group {pgid}: {err}");
+        false
+    } else {
+        true
+    }
+}
+
 pub(crate) fn pid_probe_indicates_alive(ret: i32, errno: i32) -> bool {
     ret == 0 || errno == libc::EPERM
 }


### PR DESCRIPTION
Fixes #56.

## Problem

On session timeout (`max_session_duration`) or daemon shutdown, the agent was terminated by signalling **only the direct child PID** (`terminate_child` → `send_signal(pid)` → `libc::kill(pid)`), and the agent was spawned **without its own process group**. When `agent` is a wrapper script (e.g. `run-agent.sh -> claude -> ssh host 'long-cmd'`), only the wrapper is killed; the real CLI and its grandchildren are re-parented to init and keep running. Across repeated timeouts they pile up (we observed **5 orphaned `claude` + 9 hung `ssh` (~860 MB)** from inline `ssh cluster 'conda ...'` installs that hung).

## Fix

- **`spawn_agent`** (`src/agent.rs`): place the agent in its own process group via `Command::process_group(0)` (Unix) — pgid == the agent's pid.
- **`process.rs`**: add `send_signal_group(pgid, sig)` = `libc::kill(-pgid, sig)`.
- **`terminate_child`** (`src/daemon/session.rs`): signal the whole group (SIGTERM, wait, SIGKILL), with a fallback to the bare PID in case grouping is unavailable. This covers both the timeout and the daemon-shutdown paths (both go through `terminate_child`).

Net effect: terminating a session reliably reaps `wrapper → CLI → subprocess` trees instead of leaking them.

## Tests

- Added `agent::process_group_tests::spawned_agent_is_process_group_leader` — spawns an agent and asserts `getpgid(pid) == pid`.
- `cargo build` clean; `cargo test -- --test-threads=1` → **420 passed**. The only failure I see in the full suite is the pre-existing, load-sensitive perf-threshold assertion in `daemon::tests::test_run_event_loop_drives_multiple_sessions_in_process` (`assert!(elapsed < Duration::from_secs(1))`), which also fails on `main` under full-suite load and passes 3/3 in isolation — unrelated to this change.

(Built/tested with `OPENSSL_DIR` since the box lacks `pkg-config`; no dependency changes.)
