### PR TITLE
fix: bug sweep — wake-time grammar (#49), prompt prefix-cache order (#48), contract surfacing (#50), Windows docs (#27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 Developer guidance for Claude Code (claude.ai/code) when working on this repository.
 For project overview and usage, see `README.md`.
 
+> **Scope note:** Most of this document's normative content is duplicated where its real audiences can see it: `templates/protocol.md` (for in-chamber agents — injected into every wake prompt) and `docs/src/explanation/` (for end users). What lives only here is maintainer-facing design rationale — *why* a rule exists, not *how* to follow it. When changing an operational contract, land the change in those user-visible surfaces first, then mirror it here.
+
 ## Build & Test
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The goal is to automate long-running activities that are too irregular for cron.
 ## Quick start
 
 Install Cryochamber:
+
+> **Platform support:** macOS and Linux only. Windows is not supported — the daemon relies on Unix domain sockets, POSIX signals, and launchd/systemd services (see issue #27).
+
 ```bash
 cargo install cryochamber
 ```

--- a/docs/src/how-to/troubleshoot.md
+++ b/docs/src/how-to/troubleshoot.md
@@ -83,3 +83,7 @@ Common causes:
 - The agent does not understand the `cryo-agent` protocol; check the session prompt in `cryo-agent.log`.
 
 **Break the cycle.** Remove the retry TODO with `cryo-agent todo remove <id>`, or edit `todo.json`, fix the underlying issue, then add a fresh TODO.
+
+## Windows
+
+Cryochamber does not run on Windows. The daemon's IPC uses Unix domain sockets, wake signalling uses POSIX signals (SIGUSR1), and reboot persistence uses launchd (macOS) or systemd (Linux). Use WSL2 if you need Cryochamber on a Windows machine.

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -43,7 +43,7 @@ These commands are used by the spawned AI agent to communicate with the daemon o
 | `cryo-agent hibernate --summary "..."` | End the session; more work remains. |
 | `cryo-agent hibernate --complete` | End the session; the plan is done. |
 | `cryo-agent hibernate --exit 1` | Report a failed session. The daemon marks consumed TODOs done and adds a fresh numbered retry TODO. |
-| `cryo-agent todo add "text" --at <TIME>` | Schedule the next wake via a TODO. |
+| `cryo-agent todo add "text" --at <TIME>` | Schedule the next wake via a TODO. `--at` accepts a relative offset (`+30 minutes`), an ISO 8601 timestamp (`2026-04-25T10:00`; seconds and a space separator are tolerated), or a date only (`2026-04-25`, meaning midnight). |
 | `cryo-agent todo list` | List all TODO items. |
 | `cryo-agent todo done <id>` | Mark a TODO item as done. |
 | `cryo-agent todo remove <id>` | Remove a TODO item. |

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -155,11 +155,12 @@ pub fn build_prompt(config: &AgentConfig) -> String {
         String::new()
     };
 
+    // Static-first ordering (issue #48): the byte-stable protocol body and
+    // the per-chamber task precede every per-session variable so LLM prefix
+    // caches can reuse them across wakes.
     format!(
         r#"# Cryochamber Session
 
-Session number: {session_number}
-{delayed}
 Read plan.md before starting. Follow this embedded cryochamber protocol; it is
 the source of truth for tool usage.
 
@@ -167,13 +168,17 @@ the source of truth for tool usage.
 
 {protocol}
 
-## Current Time (no need to call `cryo-agent time` again)
-
-{current_time}
-
 ## Task
 
 {task}
+
+## Session
+
+Session number: {session_number}
+{delayed}
+## Current Time (no need to call `cryo-agent time` again)
+
+{current_time}
 
 ## TODO List ({todo_hint})
 
@@ -181,10 +186,12 @@ the source of truth for tool usage.
 
 {inbox_notice}
 "#,
-        session_number = config.session_number,
-        delayed = delayed_section,
         protocol = protocol,
         task = config.task,
+        session_number = config.session_number,
+        delayed = delayed_section,
+        current_time = current_time,
+        todo_hint = todo_hint,
         todo_content = todo.content,
         inbox_notice = inbox_notice,
     )

--- a/src/bin/cryo_agent.rs
+++ b/src/bin/cryo_agent.rs
@@ -5,6 +5,7 @@ use std::io::Read;
 use std::path::Path;
 
 use cryochamber::socket::Request;
+use cryochamber::todo::normalize_wake_input;
 
 #[derive(Parser)]
 #[command(name = "cryo-agent", about = "Cryochamber agent IPC commands", version)]
@@ -47,8 +48,10 @@ enum Commands {
     Dialog(DialogArgs),
     /// Print current time, compute a future time, or validate an ISO8601 timestamp
     Time {
-        /// Input: "+N minutes|hours|days|weeks" (relative offset)
-        /// or an absolute ISO8601 timestamp like "2026-04-25T10:00"
+        /// Input: "+N minutes|hours|days|weeks" (relative offset) or an
+        /// absolute ISO8601 timestamp like "2026-04-25T10:00" (also accepts
+        /// :SS, a space separator, or date-only = midnight). Any other form
+        /// (timezone offsets, natural language) is rejected.
         offset: Option<String>,
     },
     /// Manage TODO items across sessions
@@ -77,7 +80,10 @@ enum TodoAction {
     Add {
         /// Task description
         text: String,
-        /// Scheduled time (ISO8601) — required
+        /// Wake time. Accepted forms: "+30 minutes" (relative, units:
+        /// minutes|hours|days|weeks), "2026-04-25T10:00" (ISO8601; also
+        /// accepts :SS, a space separator, or date-only = midnight).
+        /// Anything else is rejected with the list of accepted forms.
         #[arg(long)]
         at: String,
     },
@@ -178,99 +184,28 @@ fn dialog_filter_from_args(args: DialogArgs) -> Result<cryochamber::socket::Dial
 }
 
 fn cmd_time(offset: Option<&str>) -> Result<()> {
-    use chrono::Local;
-
-    let now = Local::now();
-
+    let now = chrono::Local::now().naive_local();
     let formatted = match offset {
         None => now.format("%Y-%m-%dT%H:%M").to_string(),
-        Some(s) => {
-            let s = s.trim();
-            if looks_like_iso_date(s) {
-                parse_iso_timestamp(s)?
-            } else {
-                let dt = now + parse_relative_offset(s)?;
-                dt.format("%Y-%m-%dT%H:%M").to_string()
-            }
-        }
+        Some(s) => normalize_wake_input(s, now)?,
     };
-
     println!("{formatted}");
     Ok(())
 }
 
-/// Accepted forms for `cryo-agent time` input, as a user-facing error body.
-fn time_usage_error(got: &str) -> String {
-    format!(
-        "unrecognized time expression {got:?}.\n\
-         Accepted forms:\n  \
-           (no argument)          # current time\n  \
-           +30 minutes            # relative offset (minutes|hours|days|weeks)\n  \
-           2026-04-25T10:00       # absolute ISO8601\n\
-         For natural expressions like \"tomorrow 9am\", compute the absolute\n\
-         timestamp yourself from the current time and pass it directly."
-    )
-}
-
-/// Heuristic: input starts with `YYYY-MM-DD` → try ISO8601.
-fn looks_like_iso_date(s: &str) -> bool {
-    let b = s.as_bytes();
-    b.len() >= 10
-        && b[0..4].iter().all(|c| c.is_ascii_digit())
-        && b[4] == b'-'
-        && b[5..7].iter().all(|c| c.is_ascii_digit())
-        && b[7] == b'-'
-        && b[8..10].iter().all(|c| c.is_ascii_digit())
-}
-
-/// Parse an ISO8601-ish absolute timestamp and return it normalized to `%Y-%m-%dT%H:%M`.
-fn parse_iso_timestamp(s: &str) -> Result<String> {
-    let dt_formats = [
-        "%Y-%m-%dT%H:%M",
-        "%Y-%m-%dT%H:%M:%S",
-        "%Y-%m-%d %H:%M",
-        "%Y-%m-%d %H:%M:%S",
-    ];
-    for fmt in &dt_formats {
-        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, fmt) {
-            return Ok(dt.format("%Y-%m-%dT%H:%M").to_string());
-        }
-    }
-    if let Ok(date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
-        let dt = date.and_hms_opt(0, 0, 0).unwrap();
-        return Ok(dt.format("%Y-%m-%dT%H:%M").to_string());
-    }
-    anyhow::bail!("{}", time_usage_error(s))
-}
-
-/// Parse "+N minutes|hours|days|weeks" (the `+` is optional).
-fn parse_relative_offset(s: &str) -> Result<chrono::Duration> {
-    let rel = s.trim_start_matches('+');
-    let parts: Vec<&str> = rel.splitn(2, ' ').collect();
-    if parts.len() != 2 {
-        anyhow::bail!("{}", time_usage_error(s));
-    }
-    let n: i64 = parts[0]
-        .parse()
-        .map_err(|_| anyhow::anyhow!("{}", time_usage_error(s)))?;
-    // Reject negative offsets: a past `at` time becomes an immediately-due TODO
-    // (spurious instant wake). Only non-negative relative offsets are accepted.
-    if n < 0 {
-        anyhow::bail!("{}", time_usage_error(s));
-    }
-    let unit = parts[1].trim_end_matches('s');
-    match unit {
-        "minute" | "min" => Ok(chrono::Duration::minutes(n)),
-        "hour" | "hr" => Ok(chrono::Duration::hours(n)),
-        "day" => Ok(chrono::Duration::days(n)),
-        "week" => Ok(chrono::Duration::weeks(n)),
-        _ => anyhow::bail!("{}", time_usage_error(s)),
-    }
+/// Resolve and validate a `--at` argument to the canonical wake-time form
+/// before any IPC roundtrip, so a bad value fails loudly at the CLI.
+fn resolve_at_arg(at: &str) -> Result<String> {
+    normalize_wake_input(at, chrono::Local::now().naive_local())
+        .map_err(|e| anyhow::anyhow!("invalid --at value: {e}"))
 }
 
 fn cmd_todo(dir: &Path, action: TodoAction) -> Result<()> {
     match action {
-        TodoAction::Add { text, at } => send(dir, &Request::TodoAdd { text, at }),
+        TodoAction::Add { text, at } => {
+            let at = resolve_at_arg(&at)?;
+            send(dir, &Request::TodoAdd { text, at })
+        }
         TodoAction::List => send(dir, &Request::TodoList),
         TodoAction::Done { id } => send(dir, &Request::TodoDone { id }),
         TodoAction::Remove { id } => send(dir, &Request::TodoRemove { id }),

--- a/src/bin/unit_tests/cryo_agent.rs
+++ b/src/bin/unit_tests/cryo_agent.rs
@@ -41,98 +41,36 @@ fn send_stdin_conflicts_with_text_argument() {
 }
 
 #[test]
-fn iso_pass_through_minute_precision() {
+fn resolve_at_arg_normalizes_seconds_to_minute() {
     assert_eq!(
-        parse_iso_timestamp("2026-04-25T10:00").unwrap(),
-        "2026-04-25T10:00"
+        resolve_at_arg("2026-08-01T09:15:59").unwrap(),
+        "2026-08-01T09:15"
     );
 }
 
 #[test]
-fn iso_pass_through_second_precision_truncates() {
-    assert_eq!(
-        parse_iso_timestamp("2026-04-25T10:00:42").unwrap(),
-        "2026-04-25T10:00"
-    );
+fn resolve_at_arg_rejects_garbage_before_any_ipc() {
+    let err = resolve_at_arg("tomorrow 9am").unwrap_err().to_string();
+    assert!(err.contains("invalid --at value"), "got: {err}");
+    assert!(err.contains("Accepted forms"), "got: {err}");
 }
 
 #[test]
-fn iso_space_separator_accepted() {
-    assert_eq!(
-        parse_iso_timestamp("2026-04-25 10:00").unwrap(),
-        "2026-04-25T10:00"
-    );
-}
-
-#[test]
-fn iso_date_only_gets_midnight() {
-    assert_eq!(
-        parse_iso_timestamp("2026-04-25").unwrap(),
-        "2026-04-25T00:00"
-    );
-}
-
-#[test]
-fn iso_invalid_date_rejected() {
-    let err = parse_iso_timestamp("2026-13-40").unwrap_err().to_string();
-    assert!(err.contains("unrecognized time expression"));
-}
-
-#[test]
-fn relative_offset_plus_prefix() {
-    let d = parse_relative_offset("+30 minutes").unwrap();
-    assert_eq!(d.num_minutes(), 30);
-}
-
-#[test]
-fn relative_offset_no_plus_prefix() {
-    let d = parse_relative_offset("2 hours").unwrap();
-    assert_eq!(d.num_hours(), 2);
-}
-
-#[test]
-fn relative_offset_singular_unit() {
-    let d = parse_relative_offset("+1 day").unwrap();
-    assert_eq!(d.num_days(), 1);
-}
-
-#[test]
-fn relative_offset_weeks() {
-    let d = parse_relative_offset("+2 weeks").unwrap();
-    assert_eq!(d.num_days(), 14);
-}
-
-#[test]
-fn relative_offset_negative_count_rejected() {
-    // A negative offset would produce a past time -> immediately-due TODO.
-    let err = parse_relative_offset("-30 minutes")
+fn resolve_at_arg_rejects_tz_offset() {
+    let err = resolve_at_arg("2026-05-12T07:30+08:00")
         .unwrap_err()
         .to_string();
-    assert!(err.contains("unrecognized time expression"));
-    assert!(err.contains("Accepted forms"));
+    assert!(err.contains("Accepted forms"), "got: {err}");
 }
 
 #[test]
-fn relative_offset_negative_hours_rejected() {
-    assert!(parse_relative_offset("-2 hours").is_err());
-}
-
-#[test]
-fn relative_offset_unknown_unit_lists_accepted_forms() {
-    let err = parse_relative_offset("+1 fortnight")
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("unrecognized time expression"));
-    assert!(err.contains("Accepted forms"));
-    assert!(err.contains("ISO8601"));
-}
-
-#[test]
-fn looks_like_iso_detects_date_prefix() {
-    assert!(looks_like_iso_date("2026-04-25"));
-    assert!(looks_like_iso_date("2026-04-25T10:00"));
-    assert!(!looks_like_iso_date("tomorrow 9am"));
-    assert!(!looks_like_iso_date("+30 minutes"));
+fn resolve_at_arg_accepts_relative_offset() {
+    // Result depends on the current clock; just assert canonical shape.
+    let out = resolve_at_arg("+30 minutes").unwrap();
+    assert!(
+        chrono::NaiveDateTime::parse_from_str(&out, "%Y-%m-%dT%H:%M").is_ok(),
+        "not canonical: {out}"
+    );
 }
 
 #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -643,7 +643,9 @@ impl Daemon {
             }
             DaemonRequest::Todo(todo_request) => {
                 let mut effects = FileTodoEffects::new(&self.dir);
-                let response = handle_todo_request(todo_request, &mut effects).into_response();
+                let response =
+                    handle_todo_request(todo_request, &mut effects, self.clock.local_now())
+                        .into_response();
                 let _ = responder.respond(&response);
             }
             // Reading the inbox is only valid inside an active session, which
@@ -1120,7 +1122,7 @@ impl Daemon {
                     ok,
                     message,
                     log_event,
-                } = handle_todo_request(todo_request, effects);
+                } = handle_todo_request(todo_request, effects, self.clock.local_now());
                 if let Some(event) = log_event {
                     state.logger.log_event(&event)?;
                 }

--- a/src/daemon/request.rs
+++ b/src/daemon/request.rs
@@ -327,25 +327,25 @@ impl MessageEffects for FileMessageEffects {
 pub(super) fn handle_todo_request(
     request: TodoRequest,
     effects: &mut impl TodoEffects,
+    now: chrono::NaiveDateTime,
 ) -> TodoRequestOutcome {
     match request {
         TodoRequest::Add { text, at } => {
-            // Reject an `at` that the scheduler cannot parse (including empty).
-            // Otherwise the item is accepted but `claim_due`/`next_valid_wake`
-            // skip it forever, so the TODO is never honoured.
-            if crate::todo::parse_wake_time(at.trim()).is_err() {
-                return TodoRequestOutcome {
+            // Normalize (and thereby validate) the `at` value here so the
+            // scheduler only ever sees canonical `%Y-%m-%dT%H:%M` strings.
+            // Otherwise the item would be accepted but `claim_due` /
+            // `next_valid_wake` would skip it forever, so the TODO is never
+            // honoured.
+            let at = match crate::todo::normalize_wake_input(&at, now) {
+                Ok(canonical) => canonical,
+                Err(e) => return TodoRequestOutcome {
                     ok: false,
                     message: format!(
-                        "todo add refused: `--at` value {at:?} is not a valid scheduled time. \
-                         Every TODO needs an absolute wake time. Accepted forms: \
-                         YYYY-MM-DDTHH:MM (optionally with :SS). Run \
-                         `cryo-agent time \"+30 minutes\"` (or pass an ISO8601 timestamp) \
-                         to compute TIME, then retry."
+                        "todo add refused: `--at` value {at:?} is not a valid scheduled time. {e}"
                     ),
                     log_event: None,
-                };
-            }
+                },
+            };
             match effects.add_todo(&text, &at) {
                 Ok(id) => TodoRequestOutcome {
                     ok: true,

--- a/src/daemon/request.rs
+++ b/src/daemon/request.rs
@@ -338,13 +338,15 @@ pub(super) fn handle_todo_request(
             // honoured.
             let at = match crate::todo::normalize_wake_input(&at, now) {
                 Ok(canonical) => canonical,
-                Err(e) => return TodoRequestOutcome {
-                    ok: false,
-                    message: format!(
+                Err(e) => {
+                    return TodoRequestOutcome {
+                        ok: false,
+                        message: format!(
                         "todo add refused: `--at` value {at:?} is not a valid scheduled time. {e}"
                     ),
-                    log_event: None,
-                },
+                        log_event: None,
+                    }
+                }
             };
             match effects.add_todo(&text, &at) {
                 Ok(id) => TodoRequestOutcome {

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -49,6 +49,88 @@ pub fn parse_wake_time(input: &str) -> std::result::Result<NaiveDateTime, chrono
     Err(last_error.expect("wake time input format list must not be empty"))
 }
 
+/// User-facing description of the wake-time input grammar shared by
+/// `cryo-agent time` and `cryo-agent todo add --at`.
+pub fn wake_input_usage_error(got: &str) -> String {
+    format!(
+        "unrecognized time expression {got:?}.\n\
+         Accepted forms:\n  \
+           +30 minutes            # relative offset (minutes|hours|days|weeks)\n  \
+           2026-04-25T10:00       # absolute ISO8601 (also with :SS, a space\n  \
+                                  # separator, or date-only = midnight)\n\
+         Run `cryo-agent time` for the current time. For natural expressions like\n\
+         \"tomorrow 9am\", compute the absolute timestamp yourself and pass it directly."
+    )
+}
+
+/// Normalize any accepted wake-time input to the canonical `%Y-%m-%dT%H:%M`
+/// form: a relative offset resolved against `now`, or an absolute ISO8601
+/// timestamp. Anything else fails with the accepted-forms usage error.
+pub fn normalize_wake_input(input: &str, now: NaiveDateTime) -> anyhow::Result<String> {
+    let s = input.trim();
+    if looks_like_iso_date(s) {
+        return parse_iso_timestamp(s);
+    }
+    let offset = parse_relative_offset(s)?;
+    Ok((now + offset).format(WAKE_TIME_FMT).to_string())
+}
+
+/// Heuristic: input starts with `YYYY-MM-DD` → try ISO8601.
+fn looks_like_iso_date(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() >= 10
+        && b[0..4].iter().all(|c| c.is_ascii_digit())
+        && b[4] == b'-'
+        && b[5..7].iter().all(|c| c.is_ascii_digit())
+        && b[7] == b'-'
+        && b[8..10].iter().all(|c| c.is_ascii_digit())
+}
+
+/// Parse an ISO8601-ish absolute timestamp and return it normalized to `%Y-%m-%dT%H:%M`.
+pub fn parse_iso_timestamp(s: &str) -> anyhow::Result<String> {
+    let dt_formats = [
+        "%Y-%m-%dT%H:%M",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d %H:%M:%S",
+    ];
+    for fmt in &dt_formats {
+        if let Ok(dt) = NaiveDateTime::parse_from_str(s, fmt) {
+            return Ok(dt.format(WAKE_TIME_FMT).to_string());
+        }
+    }
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        let dt = date.and_hms_opt(0, 0, 0).unwrap();
+        return Ok(dt.format(WAKE_TIME_FMT).to_string());
+    }
+    anyhow::bail!("{}", wake_input_usage_error(s))
+}
+
+/// Parse "+N minutes|hours|days|weeks" (the `+` is optional).
+pub fn parse_relative_offset(s: &str) -> anyhow::Result<chrono::Duration> {
+    let rel = s.trim_start_matches('+');
+    let parts: Vec<&str> = rel.splitn(2, ' ').collect();
+    if parts.len() != 2 {
+        anyhow::bail!("{}", wake_input_usage_error(s));
+    }
+    let n: i64 = parts[0]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("{}", wake_input_usage_error(s)))?;
+    // Reject negative offsets: a past `at` time becomes an immediately-due TODO
+    // (spurious instant wake). Only non-negative relative offsets are accepted.
+    if n < 0 {
+        anyhow::bail!("{}", wake_input_usage_error(s));
+    }
+    let unit = parts[1].trim_end_matches('s');
+    match unit {
+        "minute" | "min" => Ok(chrono::Duration::minutes(n)),
+        "hour" | "hr" => Ok(chrono::Duration::hours(n)),
+        "day" => Ok(chrono::Duration::days(n)),
+        "week" => Ok(chrono::Duration::weeks(n)),
+        _ => anyhow::bail!("{}", wake_input_usage_error(s)),
+    }
+}
+
 impl TodoFile {
     pub fn new(path: impl AsRef<Path>) -> Self {
         Self {

--- a/src/unit_tests/daemon.rs
+++ b/src/unit_tests/daemon.rs
@@ -1045,6 +1045,10 @@ fn test_handle_todo_request_returns_response_and_log_event() {
             at: "2026-03-01T13:00".into(),
         },
         &mut effects,
+        chrono::NaiveDate::from_ymd_opt(2026, 3, 1)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap(),
     );
 
     assert_eq!(

--- a/src/unit_tests/daemon/request.rs
+++ b/src/unit_tests/daemon/request.rs
@@ -7,6 +7,13 @@ use crate::socket::DialogFilter;
 use chrono::NaiveDate;
 use std::collections::BTreeMap;
 
+fn request_now() -> chrono::NaiveDateTime {
+    chrono::NaiveDate::from_ymd_opt(2026, 7, 8)
+        .unwrap()
+        .and_hms_opt(12, 0, 0)
+        .unwrap()
+}
+
 fn msg(from: &str, body: &str, day: u32, hour: u32) -> Message {
     Message {
         from: from.to_string(),
@@ -90,6 +97,7 @@ fn todo_add_rejects_unparseable_at_without_adding() {
             at: "tomorrow 9am".to_string(),
         },
         &mut fake,
+        request_now(),
     );
     assert!(!out.ok, "an unparseable at must be rejected");
     assert!(out.message.contains("not a valid scheduled time"));
@@ -110,6 +118,7 @@ fn todo_add_rejects_empty_at() {
             at: String::new(),
         },
         &mut fake,
+        request_now(),
     );
     assert!(!out.ok, "empty at must be rejected");
     assert!(fake.added.is_empty());
@@ -124,12 +133,65 @@ fn todo_add_accepts_valid_at() {
             at: "2026-04-25T10:00".to_string(),
         },
         &mut fake,
+        request_now(),
     );
     assert!(out.ok);
     assert_eq!(
         fake.added,
         vec![("task".to_string(), "2026-04-25T10:00".to_string())]
     );
+}
+
+#[test]
+fn todo_add_normalizes_relative_offset_against_now() {
+    let mut fake = FakeTodos::default();
+    let out = handle_todo_request(
+        TodoRequest::Add {
+            text: "water the plants".to_string(),
+            at: "+30 minutes".to_string(),
+        },
+        &mut fake,
+        request_now(),
+    );
+    assert!(out.ok, "relative offsets must be accepted: {out:?}");
+    assert_eq!(
+        fake.added,
+        vec![(
+            "water the plants".to_string(),
+            "2026-07-08T12:30".to_string()
+        )]
+    );
+}
+
+#[test]
+fn todo_add_normalizes_seconds_to_canonical_minute() {
+    let mut fake = FakeTodos::default();
+    let out = handle_todo_request(
+        TodoRequest::Add {
+            text: "brief".to_string(),
+            at: "2026-08-01T09:15:59".to_string(),
+        },
+        &mut fake,
+        request_now(),
+    );
+    assert!(out.ok);
+    assert_eq!(fake.added[0].1, "2026-08-01T09:15");
+}
+
+#[test]
+fn todo_add_rejects_tz_offset_loudly() {
+    let mut fake = FakeTodos::default();
+    let out = handle_todo_request(
+        TodoRequest::Add {
+            text: "daily brief".to_string(),
+            at: "2026-05-12T07:30+08:00".to_string(),
+        },
+        &mut fake,
+        request_now(),
+    );
+    assert!(!out.ok, "a TZ-offset at must be rejected");
+    assert!(out.message.contains("not a valid scheduled time"));
+    assert!(fake.added.is_empty());
 }
 
 #[test]

--- a/src/unit_tests/todo.rs
+++ b/src/unit_tests/todo.rs
@@ -324,3 +324,75 @@ fn test_todo_file_reschedule_claimed_after_crash_marks_claimed_done_and_adds_ret
     assert!(!items[1].done);
     assert!(!items[1].claimed);
 }
+
+fn grammar_now() -> chrono::NaiveDateTime {
+    chrono::NaiveDate::from_ymd_opt(2026, 7, 8)
+        .unwrap()
+        .and_hms_opt(12, 0, 0)
+        .unwrap()
+}
+
+#[test]
+fn normalize_relative_offset_resolves_against_now() {
+    assert_eq!(
+        normalize_wake_input("+30 minutes", grammar_now()).unwrap(),
+        "2026-07-08T12:30"
+    );
+    assert_eq!(
+        normalize_wake_input("2 hours", grammar_now()).unwrap(),
+        "2026-07-08T14:00"
+    );
+}
+
+#[test]
+fn normalize_iso_minute_is_passthrough() {
+    assert_eq!(
+        normalize_wake_input("2026-08-01T09:15", grammar_now()).unwrap(),
+        "2026-08-01T09:15"
+    );
+}
+
+#[test]
+fn normalize_iso_seconds_truncates_to_minute() {
+    assert_eq!(
+        normalize_wake_input("2026-08-01T09:15:59", grammar_now()).unwrap(),
+        "2026-08-01T09:15"
+    );
+}
+
+#[test]
+fn normalize_iso_space_separator_accepted() {
+    assert_eq!(
+        normalize_wake_input("2026-08-01 09:15", grammar_now()).unwrap(),
+        "2026-08-01T09:15"
+    );
+}
+
+#[test]
+fn normalize_date_only_means_midnight() {
+    assert_eq!(
+        normalize_wake_input("2026-08-01", grammar_now()).unwrap(),
+        "2026-08-01T00:00"
+    );
+}
+
+#[test]
+fn normalize_rejects_tz_offset_with_usage_error() {
+    let err = normalize_wake_input("2026-08-01T09:15+08:00", grammar_now())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("Accepted forms"), "got: {err}");
+}
+
+#[test]
+fn normalize_rejects_negative_offset() {
+    assert!(normalize_wake_input("-5 minutes", grammar_now()).is_err());
+}
+
+#[test]
+fn normalize_rejects_natural_language() {
+    let err = normalize_wake_input("tomorrow 9am", grammar_now())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("Accepted forms"), "got: {err}");
+}

--- a/templates/protocol.md
+++ b/templates/protocol.md
@@ -12,7 +12,7 @@ Execute these steps in order. **Do not skip or reorder steps.**
 
 ### Step 1: Orient
 
-The wake prompt carries session-dynamic context (`## Current Time`, `## Task`, `## TODO List`, `## Inbox`, and after a delayed wake `## System Notice`) — don't re-fetch what's already there. Claimed `[~]` TODOs are the ones that triggered this wake. A header ending in `(use <cmd> to get full text)` means the content was truncated — run the named command.
+The wake prompt carries your per-chamber and per-session context (`## Task`, `## Session`, `## Current Time`, `## TODO List`, `## Inbox`, and after a delayed wake `## System Notice`) — don't re-fetch what's already there. Claimed `[~]` TODOs are the ones that triggered this wake. A header ending in `(use <cmd> to get full text)` means the content was truncated — run the named command.
 
 Then read `plan.md` for objectives and `NOTES.md` for context from previous sessions.
 
@@ -69,7 +69,7 @@ Add a TODO only when no existing one represents the correct next wake:
 cryo-agent todo add "<what to do next>" --at <TIME>
 ```
 
-`--at` accepts exactly these forms — anything else (timezone offsets, natural language) is rejected with this list:
+`--at` accepts these forms — anything else (timezone offsets, natural language) is rejected with this list:
 
 - `+30 minutes` — relative offset; units: `minutes|hours|days|weeks`
 - `2026-04-25T10:00` — absolute ISO8601 (seconds and a space separator are accepted and truncated to the minute)

--- a/templates/protocol.md
+++ b/templates/protocol.md
@@ -19,6 +19,7 @@ Then read `plan.md` for objectives and `NOTES.md` for context from previous sess
 ### Step 2: Work
 
 - The only supported way to communicate with the human is through `cryo-agent send` (stdout/stderr are diagnostic logs, not a channel). Send at least once per session, even if it's only a status update that nothing changed.
+- Never write files into `messages/outbox/` yourself — `cryo-agent send` is the only supported way to produce an outbox message; direct writes bypass the daemon's reply bookkeeping.
 - If your outgoing message asks a question, requests a decision, asks for approval, or otherwise requires human feedback, you MUST use `cryo-agent send --question "<message>"`.
 - If the message is multi-line or contains shell-sensitive text (quotes, `$`, or backticks), do not put the body in a shell-quoted argument. Use `--stdin` with a single-quoted literal heredoc so the shell cannot expand the content. Stdin is sent exactly, including the final newline before `EOF`:
 
@@ -68,7 +69,13 @@ Add a TODO only when no existing one represents the correct next wake:
 cryo-agent todo add "<what to do next>" --at <TIME>
 ```
 
-Compute `<TIME>` via `cryo-agent time` — never invent a wall-clock string.
+`--at` accepts exactly these forms — anything else (timezone offsets, natural language) is rejected with this list:
+
+- `+30 minutes` — relative offset; units: `minutes|hours|days|weeks`
+- `2026-04-25T10:00` — absolute ISO8601 (seconds and a space separator are accepted and truncated to the minute)
+- `2026-04-25` — date-only, meaning midnight
+
+Compute absolute times via `cryo-agent time` — never invent a wall-clock string.
 
 Always perform this check, even if the next wake is "just in case the human messages." The only session that skips Step 4 is one ending with `hibernate --complete`.
 
@@ -82,7 +89,7 @@ cryo-agent hibernate --complete --summary "All tasks finished"      # plan's suc
 cryo-agent hibernate --exit 1 --summary "Failure: why to retry"     # retryable failure
 ```
 
-If you exit without calling `cryo-agent hibernate`, the daemon marks each claimed TODO done and creates a fresh retry TODO with an `(attempt k)` suffix and a `2^k`-minute delay (capped at 1 day).
+If you exit without calling `cryo-agent hibernate`, the daemon marks each claimed TODO done and creates a fresh retry TODO with an `(attempt k)` suffix and a `2^k`-minute delay (capped at 1 day). The daemon also writes a stand-in `from: cryochamber` outbox message if you never sent a human-visible message this session — don't make the human read a crash notice instead of your words.
 
 ## Wake Time Guidelines
 
@@ -102,11 +109,11 @@ EOF
 cryo-agent send --question "what should I do?"  # Send a question (rail shows ? until human replies)
 cryo-agent receive                                               # Claim current inbox batch from human
 cryo-agent dialog [--last N | --all]                             # Render full sent+received transcript; also claims any pending inbox batch
-cryo-agent todo add "text" --at <TIME>                           # Schedule a task (--at required) — ONLY way to set next wake
+cryo-agent todo add "text" --at <TIME>                           # Schedule a task — ONLY way to set next wake; --at takes "+30 minutes", ISO8601, or date-only
 cryo-agent todo list                                             # List all TODO items
 cryo-agent todo done <id>                                        # Mark item as done
 cryo-agent todo remove <id>                                      # Remove an item
 cryo-agent time                                                  # Current time in ISO8601
-cryo-agent time "+1 day"                                         # Relative time computation
+cryo-agent time "+1 day"                                         # Relative time computation (other forms: ISO8601, date-only; anything else is rejected)
 cryo-agent hibernate [--complete|--exit N] [--summary "..."]     # End the session (no wake arg — wakes come from TODOs)
 ```

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -280,3 +280,45 @@ fn test_build_command_claude_p_flag_is_idempotent() {
     assert_eq!(args.iter().filter(|arg| arg.as_str() == "-p").count(), 1);
     assert_eq!(args.last().map(String::as_str), Some("test prompt"));
 }
+
+/// #48: everything that is byte-stable across wakes (the protocol body and
+/// the per-chamber task) must precede all per-session variables, so LLM
+/// prefix caches can reuse it. Guard the invariant by asserting the common
+/// byte prefix of two maximally-different sessions still spans the protocol
+/// and task sections.
+#[test]
+fn prompt_static_prefix_precedes_all_per_session_variables() {
+    let task = "Watch the CI dashboard and report failures.";
+    let a = cryochamber::agent::build_prompt(&cryochamber::agent::AgentConfig {
+        session_number: 1,
+        task: task.to_string(),
+        delayed_wake: None,
+        todo_list: "No todos.".to_string(),
+        inbox_waiting: false,
+        inbox_sources: vec![],
+    });
+    let b = cryochamber::agent::build_prompt(&cryochamber::agent::AgentConfig {
+        session_number: 42,
+        task: task.to_string(),
+        delayed_wake: Some("The machine was suspended.".to_string()),
+        todo_list: "1. [ ] check CI (at: 2026-07-09T09:00)".to_string(),
+        inbox_waiting: true,
+        inbox_sources: vec!["messages/inbox".to_string()],
+    });
+
+    let common: usize = a.bytes().zip(b.bytes()).take_while(|(x, y)| x == y).count();
+    let common_str = &a[..common];
+
+    assert!(
+        common_str.contains("## Cryochamber Protocol"),
+        "protocol heading must be in the shared prefix (common = {common} bytes)"
+    );
+    assert!(
+        common_str.contains(task),
+        "the per-chamber task must be in the shared prefix (common = {common} bytes)"
+    );
+    assert!(
+        common >= 4000,
+        "shared prefix must span the protocol body, got {common} bytes"
+    );
+}


### PR DESCRIPTION
## Summary

Single PR resolving all bug-shaped open issues:

- **#49** — `cryo-agent todo add --at` values are now validated and normalized with the same grammar as `cryo-agent time`, at both the CLI boundary (loud error before any IPC) and the daemon's `TodoAdd` handler (defense-in-depth for other clients; stores canonical `%Y-%m-%dT%H:%M`). Relative offsets (`--at "+30 minutes"`) and date-only forms now work directly. The scheduler itself is unchanged and stays strict, so existing `todo.json` files (including seconds-precision values) keep parsing.
- **#48** — `build_prompt` now emits the byte-stable protocol body and per-chamber task before every per-session variable, so LLM prefix caches can reuse ~6.5 KB per wake. Guarded by a prefix-stability integration test (shared prefix must span the protocol and task, ≥4000 bytes).
- **#50** — the operational contract (wake-time grammar, outbox write path, crash stand-in messages) now lives in `templates/protocol.md` (the in-chamber agent's only guaranteed context surface) and in exhaustive `--help` text; CLAUDE.md carries a scope note marking it as maintainer-facing rationale.
- **#27** — README and the troubleshooting guide now state that Windows is unsupported and why (Unix domain sockets, POSIX signals, launchd/systemd), with WSL2 as the workaround.

Note: #56 (process-group kill) needed no changes — it was already fixed by 57ab612 (PR #58) and is closed separately with a comment.

## Follow-ups deliberately not in this PR

- Consolidate `parse_dialog_since` (`src/daemon/request.rs`) and the duplicate `WAKE_TIME_FMT` in `src/daemon/schedule.rs` onto the shared grammar helpers.
- Optionally tighten `parse_relative_offset` (unit aliases `min`/`hr`, no trim of the unit part).

## Test plan

- `make check` green (fmt, clippy `-D warnings`, full test suite).
- New tests: 8 grammar unit tests (`src/unit_tests/todo.rs`), 4 CLI-boundary tests (`src/bin/unit_tests/cryo_agent.rs`), 3 daemon normalization tests (`src/unit_tests/daemon/request.rs`), 1 prompt prefix-stability integration test (`tests/agent_tests.rs`).
- `make book` builds cleanly.

Closes #49
Closes #48
Closes #50
Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)