### PR TITLE
feat: archive chambers from the hub (#59)

### DIFF
--- a/docs/src/how-to/monitor-chambers.md
+++ b/docs/src/how-to/monitor-chambers.md
@@ -21,8 +21,9 @@ cryohub start --foreground
 
 ### Use the dashboard
 
-- **Sidebar** - every registered chamber, sorted by running state and name. Each row shows a status dot and an unread-message badge.
+- **Sidebar** - every registered chamber, sorted by running state and name. Each row shows a status dot and an unread-message badge. Completed and archived chambers fold into collapsible **Completed** and **Archived** sections at the bottom.
 - **Main pane** - full detail for the selected chamber: status, current task, next wake time, notes, message history, log tail, and a send widget. Lifecycle buttons, Start, Stop, Restart, and Wake, sit next to the status.
+- **Archive** - a stopped chamber shows an **Archive** button that folds it out of the active list into the **Archived** section without moving any files. Archiving is reversible: an archived chamber offers only **Unarchive**, which returns it to the active list (still stopped) so you can Launch it again. A running chamber must be stopped first.
 - **New Chamber** modal - scaffolds a chamber under the configured chamber root, `~/.cryo/chambers` by default.
 
 ### Manage the hub service

--- a/src/hub/discovery.rs
+++ b/src/hub/discovery.rs
@@ -53,6 +53,10 @@ pub struct ChamberEntry {
     pub task: Option<String>,
     pub last_message_preview: Option<String>,
     pub completed: bool,
+    /// Hub display state carried from the registry: archived chambers fold into
+    /// the dashboard's "Archived" section and cannot be launched until
+    /// unarchived. Not a runtime field — `populate_runtime` leaves it untouched.
+    pub archived: bool,
     pub sync: Vec<SyncBadge>,
 }
 
@@ -126,6 +130,7 @@ pub fn scan_workspace(dir: &Path) -> ChamberIndex {
                 task: None,
                 last_message_preview: None,
                 completed: false,
+                archived: false,
                 sync: vec![],
             },
         );
@@ -180,6 +185,7 @@ fn registry_entry_for_path(workspace: &Path, path: PathBuf) -> Option<ChamberEnt
         task: None,
         last_message_preview: None,
         completed: false,
+        archived: false,
         sync: vec![],
     })
 }
@@ -192,10 +198,12 @@ fn merge_registry(workspace: &Path, idx: &mut ChamberIndex) {
         .canonicalize()
         .unwrap_or_else(|_| workspace.to_path_buf());
     for registered in entries {
+        let archived = registered.archived;
         let path = PathBuf::from(registered.dir);
-        let Some(entry) = registry_entry_for_path(&workspace, path) else {
+        let Some(mut entry) = registry_entry_for_path(&workspace, path) else {
             continue;
         };
+        entry.archived = archived;
         idx.entry(entry.id.clone()).or_insert(entry);
     }
 }

--- a/src/hub/lifecycle.rs
+++ b/src/hub/lifecycle.rs
@@ -47,6 +47,22 @@ pub fn archive_runtime(dir: &Path) -> Result<PathBuf> {
     crate::lifecycle::archive_runtime(dir)
 }
 
+/// Archive a chamber: fold it out of the hub's active grid. The daemon must be
+/// stopped first — archived chambers cannot run until unarchived. Reversible
+/// via `unarchive_chamber`; no files are moved. Only touches the registry flag.
+pub fn archive_chamber(dir: &Path) -> Result<()> {
+    if crate::chamber_status::overview(dir).running {
+        anyhow::bail!("Stop the chamber before archiving it");
+    }
+    crate::registry::set_archived(dir, true)
+}
+
+/// Unarchive a chamber: return it to the active grid. Leaves it stopped — the
+/// operator presses Launch to run it again.
+pub fn unarchive_chamber(dir: &Path) -> Result<()> {
+    crate::registry::set_archived(dir, false)
+}
+
 /// Reset the chamber: stop the daemon (if running) and archive runtime state
 /// under `history/<timestamp>/`. Leaves the chamber stopped — the operator
 /// presses Start when they want a new session. Re-creates `messages/` so

--- a/src/hub/lifecycle.rs
+++ b/src/hub/lifecycle.rs
@@ -9,6 +9,9 @@ use crate::channel::store::MessageStore;
 
 /// Start a daemon for the chamber at `dir`. Mirrors `cmd_start` in the CLI.
 pub fn start_chamber(dir: &Path) -> Result<()> {
+    if crate::registry::is_archived(dir) {
+        anyhow::bail!("Unarchive the chamber before launching it");
+    }
     let exe = resolve_cryo_exe()?;
     let prepared = crate::lifecycle::prepare_start(dir, crate::lifecycle::StartOptions::default())?;
     crate::lifecycle::validate_agent_command(&prepared.effective_agent, exe.parent())?;

--- a/src/hub/mod.rs
+++ b/src/hub/mod.rs
@@ -92,6 +92,14 @@ pub fn build_router_with_state(app: Arc<WebAppState>) -> Router {
             post(crate::hub::routes::chamber::post_reset),
         )
         .route(
+            "/api/chambers/{id}/archive",
+            post(crate::hub::routes::chamber::post_archive),
+        )
+        .route(
+            "/api/chambers/{id}/unarchive",
+            post(crate::hub::routes::chamber::post_unarchive),
+        )
+        .route(
             "/api/chambers/{id}/sync",
             get(crate::hub::routes::sync::get_sync),
         )

--- a/src/hub/routes/chamber.rs
+++ b/src/hub/routes/chamber.rs
@@ -160,7 +160,13 @@ pub async fn post_start(
     State(app): State<Arc<AppState>>,
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<Value>, StatusCode> {
-    let (path, _entry) = app.resolve(&id).ok_or(StatusCode::NOT_FOUND)?;
+    let (path, entry) = app.resolve(&id).ok_or(StatusCode::NOT_FOUND)?;
+    if entry.archived {
+        return Ok(Json(json!({
+            "ok": false,
+            "message": "Unarchive the chamber before launching it",
+        })));
+    }
     let result = run_blocking_lifecycle(app, path, crate::hub::lifecycle::start_chamber).await;
     Ok(Json(lifecycle_status_json(result, "Started")))
 }

--- a/src/hub/routes/chamber.rs
+++ b/src/hub/routes/chamber.rs
@@ -203,6 +203,24 @@ pub async fn post_reset(
     }
 }
 
+pub async fn post_archive(
+    State(app): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<Value>, StatusCode> {
+    let (path, _entry) = app.resolve(&id).ok_or(StatusCode::NOT_FOUND)?;
+    let result = run_blocking_lifecycle(app, path, crate::hub::lifecycle::archive_chamber).await;
+    Ok(Json(lifecycle_status_json(result, "Archived")))
+}
+
+pub async fn post_unarchive(
+    State(app): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<Value>, StatusCode> {
+    let (path, _entry) = app.resolve(&id).ok_or(StatusCode::NOT_FOUND)?;
+    let result = run_blocking_lifecycle(app, path, crate::hub::lifecycle::unarchive_chamber).await;
+    Ok(Json(lifecycle_status_json(result, "Unarchived")))
+}
+
 fn lifecycle_status_json(result: anyhow::Result<()>, success_message: &str) -> Value {
     match result {
         Ok(()) => json!({"ok": true, "message": success_message}),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -18,6 +18,13 @@ pub struct DaemonEntry {
     pub dir: String,
     #[serde(default)]
     pub socket_path: Option<String>,
+    /// Hub display state: archived chambers are folded away in the dashboard
+    /// and cannot be started until unarchived. Purely a Cryohub concern — the
+    /// CLI ignores it. Only `set_archived` mutates this; `register`,
+    /// `unregister`, and `remember_chamber` preserve whatever is on disk so a
+    /// daemon start/stop cycle never clears the flag.
+    #[serde(default)]
+    pub archived: bool,
 }
 
 /// Return the registry directory, creating it if needed.
@@ -35,11 +42,21 @@ fn registry_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
-/// Stable filename for a given working directory.
+/// Canonicalize a chamber directory so symlinked path forms (e.g. macOS
+/// `/var` → `/private/var`) resolve to a single registry entry. Discovery keys
+/// chambers by their canonical path, so registry writes must agree or the same
+/// chamber ends up with two entries. Falls back to the raw path when the
+/// directory does not exist yet (e.g. pruning tests).
+fn canonical_dir(dir: &Path) -> PathBuf {
+    dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf())
+}
+
+/// Stable filename for a given working directory. The directory is
+/// canonicalized first so every path form of the same chamber hashes alike.
 fn entry_filename(dir: &Path) -> String {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    dir.hash(&mut hasher);
+    canonical_dir(dir).hash(&mut hasher);
     format!("{:016x}.json", hasher.finish())
 }
 
@@ -51,6 +68,7 @@ pub fn remember_chamber(dir: &Path) -> Result<()> {
             pid: None,
             dir: dir.to_string_lossy().to_string(),
             socket_path: None,
+            archived: read_archived(dir),
         },
     )
 }
@@ -63,8 +81,38 @@ pub fn register(dir: &Path, socket_path: Option<&Path>) -> Result<()> {
             pid: Some(std::process::id()),
             dir: dir.to_string_lossy().to_string(),
             socket_path: socket_path.map(|p| p.to_string_lossy().to_string()),
+            archived: read_archived(dir),
         },
     )
+}
+
+/// Read the persisted `archived` flag for a chamber, defaulting to `false`
+/// when there is no entry yet or it cannot be parsed. Used to carry the flag
+/// across `register`/`unregister`/`remember_chamber`, which otherwise rewrite
+/// the whole entry.
+fn read_archived(dir: &Path) -> bool {
+    read_entry(dir).map(|e| e.archived).unwrap_or(false)
+}
+
+/// Read the current on-disk entry for a chamber, if any.
+fn read_entry(dir: &Path) -> Option<DaemonEntry> {
+    let reg = registry_dir().ok()?;
+    let path = reg.join(entry_filename(dir));
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Set the hub `archived` flag for a chamber, preserving all other fields.
+/// Creates a minimal entry if none exists yet.
+pub fn set_archived(dir: &Path, archived: bool) -> Result<()> {
+    let mut entry = read_entry(dir).unwrap_or_else(|| DaemonEntry {
+        pid: None,
+        dir: dir.to_string_lossy().to_string(),
+        socket_path: None,
+        archived: false,
+    });
+    entry.archived = archived;
+    write_entry(dir, entry)
 }
 
 fn write_entry(dir: &Path, entry: DaemonEntry) -> Result<()> {
@@ -80,6 +128,7 @@ pub fn unregister(dir: &Path) {
         pid: None,
         dir: dir.to_string_lossy().to_string(),
         socket_path: None,
+        archived: read_archived(dir),
     };
     let _ = write_entry(dir, entry);
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -94,6 +94,11 @@ fn read_archived(dir: &Path) -> bool {
     read_entry(dir).map(|e| e.archived).unwrap_or(false)
 }
 
+/// Return whether a chamber is archived in the hub registry.
+pub fn is_archived(dir: &Path) -> bool {
+    read_archived(dir)
+}
+
 /// Read the current on-disk entry for a chamber, if any.
 fn read_entry(dir: &Path) -> Option<DaemonEntry> {
     let reg = registry_dir().ok()?;
@@ -136,34 +141,43 @@ pub fn unregister(dir: &Path) {
 /// List all remembered chambers. Missing chamber directories are pruned;
 /// dead PIDs are cleared so the entry remains visible as stopped.
 pub fn list() -> Result<Vec<DaemonEntry>> {
+    struct Candidate {
+        entry: DaemonEntry,
+        file_path: PathBuf,
+        canonical_file: PathBuf,
+        is_canonical_file: bool,
+    }
+
     let reg = registry_dir()?;
-    let mut entries = Vec::new();
+    let mut entries = std::collections::BTreeMap::<PathBuf, Candidate>::new();
+    let mut remove_paths = Vec::new();
 
     let dir = match std::fs::read_dir(&reg) {
-        Ok(d) => d,
-        Err(_) => return Ok(entries),
+        Ok(dir) => dir,
+        Err(_) => return Ok(Vec::new()),
     };
 
     for file in dir {
         let file = file?;
-        if file.path().extension().is_none_or(|ext| ext != "json") {
+        let file_path = file.path();
+        if file_path.extension().is_none_or(|ext| ext != "json") {
             continue;
         }
-        let content = match std::fs::read_to_string(file.path()) {
+        let content = match std::fs::read_to_string(&file_path) {
             Ok(c) => c,
             Err(_) => continue,
         };
         let mut entry: DaemonEntry = match serde_json::from_str(&content) {
             Ok(e) => e,
             Err(_) => {
-                let _ = std::fs::remove_file(file.path());
+                let _ = std::fs::remove_file(&file_path);
                 continue;
             }
         };
 
         let chamber_dir = PathBuf::from(&entry.dir);
         if !crate::config::config_path(&chamber_dir).exists() {
-            let _ = std::fs::remove_file(file.path());
+            let _ = std::fs::remove_file(&file_path);
             continue;
         }
 
@@ -171,14 +185,55 @@ pub fn list() -> Result<Vec<DaemonEntry>> {
             if !is_pid_alive(pid) {
                 entry.pid = None;
                 entry.socket_path = None;
-                let _ = std::fs::write(file.path(), serde_json::to_string(&entry)?);
             }
         }
 
-        entries.push(entry);
+        let canonical = canonical_dir(&chamber_dir);
+        let canonical_file = reg.join(entry_filename(&canonical));
+        let candidate = Candidate {
+            entry,
+            is_canonical_file: file_path == canonical_file,
+            file_path,
+            canonical_file,
+        };
+
+        match entries.entry(canonical) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert(candidate);
+            }
+            std::collections::btree_map::Entry::Occupied(mut slot) => {
+                if candidate.is_canonical_file && !slot.get().is_canonical_file {
+                    remove_paths.push(slot.get().file_path.clone());
+                    slot.insert(candidate);
+                } else {
+                    remove_paths.push(candidate.file_path);
+                }
+            }
+        }
     }
 
-    Ok(entries)
+    let mut out = Vec::new();
+    for candidate in entries.into_values() {
+        if candidate.file_path != candidate.canonical_file {
+            std::fs::write(
+                &candidate.canonical_file,
+                serde_json::to_string(&candidate.entry)?,
+            )?;
+            remove_paths.push(candidate.file_path);
+        } else {
+            std::fs::write(
+                &candidate.file_path,
+                serde_json::to_string(&candidate.entry)?,
+            )?;
+        }
+        out.push(candidate.entry);
+    }
+
+    for path in remove_paths {
+        let _ = std::fs::remove_file(path);
+    }
+
+    Ok(out)
 }
 
 fn is_pid_alive(pid: u32) -> bool {

--- a/src/unit_tests/hub/lifecycle.rs
+++ b/src/unit_tests/hub/lifecycle.rs
@@ -238,3 +238,17 @@ fn archive_chamber_refuses_while_daemon_running() {
     let err = archive_chamber(dir.path()).unwrap_err();
     assert!(err.to_string().contains("Stop the chamber"));
 }
+
+#[test]
+fn start_chamber_refuses_archived_chamber_before_launch_preflight() {
+    let state_home = tempfile::tempdir().unwrap();
+    let _guard = crate::test_support::EnvVarGuard::set_path("XDG_STATE_HOME", state_home.path());
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = crate::config::CryoConfig::default();
+    crate::config::save_config(&crate::config::config_path(dir.path()), &cfg).unwrap();
+    crate::registry::set_archived(dir.path(), true).unwrap();
+
+    let err = start_chamber(dir.path()).unwrap_err();
+
+    assert!(err.to_string().contains("Unarchive"));
+}

--- a/src/unit_tests/hub/lifecycle.rs
+++ b/src/unit_tests/hub/lifecycle.rs
@@ -190,3 +190,51 @@ fn resolve_cryo_exe_from_test_binary_prefers_target_debug_cryo() {
     let resolved = resolve_cryo_exe_from(&test_bin, || None).unwrap();
     assert_eq!(resolved, cryo);
 }
+
+#[test]
+fn archive_and_unarchive_toggle_the_registry_flag() {
+    let state_home = tempfile::tempdir().unwrap();
+    let _guard = crate::test_support::EnvVarGuard::set_path("XDG_STATE_HOME", state_home.path());
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = crate::config::CryoConfig::default();
+    crate::config::save_config(&crate::config::config_path(dir.path()), &cfg).unwrap();
+    let chamber = dir.path().canonicalize().unwrap();
+    crate::registry::remember_chamber(&chamber).unwrap();
+
+    let archived = |c: &std::path::Path| {
+        crate::registry::list()
+            .unwrap()
+            .into_iter()
+            .find(|e| e.dir == c.display().to_string())
+            .unwrap()
+            .archived
+    };
+
+    archive_chamber(&chamber).unwrap();
+    assert!(archived(&chamber), "archive sets the flag");
+    unarchive_chamber(&chamber).unwrap();
+    assert!(!archived(&chamber), "unarchive clears the flag");
+}
+
+#[test]
+fn archive_chamber_refuses_while_daemon_running() {
+    let state_home = tempfile::tempdir().unwrap();
+    let _guard = crate::test_support::EnvVarGuard::set_path("XDG_STATE_HOME", state_home.path());
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = crate::config::CryoConfig::default();
+    crate::config::save_config(&crate::config::config_path(dir.path()), &cfg).unwrap();
+    // A live pid (our own) makes the chamber look running to `overview`.
+    let st = crate::state::CryoState {
+        session_number: 1,
+        pid: Some(std::process::id()),
+        agent_override: None,
+        max_session_duration_override: None,
+        instance_id: None,
+        session_active: false,
+        previous_session_crashed: false,
+    };
+    crate::state::save_state(&crate::state::state_path(dir.path()), &st).unwrap();
+
+    let err = archive_chamber(dir.path()).unwrap_err();
+    assert!(err.to_string().contains("Stop the chamber"));
+}

--- a/src/unit_tests/hub/routes/chamber.rs
+++ b/src/unit_tests/hub/routes/chamber.rs
@@ -31,6 +31,47 @@ async fn post_start_refuses_archived_chamber_without_launching() {
     assert!(v["message"].as_str().unwrap_or("").contains("Unarchive"));
 }
 
+#[tokio::test]
+async fn post_archive_sets_registry_flag_for_stopped_chamber() {
+    let state_home = tempfile::tempdir().unwrap();
+    let _guard = crate::test_support::EnvVarGuard::set_path("XDG_STATE_HOME", state_home.path());
+    let workspace = tempfile::tempdir().unwrap();
+    let chamber = workspace.path().join("alpha");
+    std::fs::create_dir_all(&chamber).unwrap();
+    let cfg = crate::config::CryoConfig::default();
+    crate::config::save_config(&chamber.join("cryo.toml"), &cfg).unwrap();
+
+    let app = Arc::new(AppState::local_only(workspace.path().to_path_buf()));
+    app.refresh();
+    let id = app.chambers.read().unwrap().keys().next().unwrap().clone();
+
+    let Json(v) = post_archive(State(app), AxumPath(id)).await.unwrap();
+
+    assert_eq!(v["ok"], true);
+    assert!(crate::registry::is_archived(&chamber));
+}
+
+#[tokio::test]
+async fn post_unarchive_clears_registry_flag() {
+    let state_home = tempfile::tempdir().unwrap();
+    let _guard = crate::test_support::EnvVarGuard::set_path("XDG_STATE_HOME", state_home.path());
+    let workspace = tempfile::tempdir().unwrap();
+    let chamber = workspace.path().join("alpha");
+    std::fs::create_dir_all(&chamber).unwrap();
+    let cfg = crate::config::CryoConfig::default();
+    crate::config::save_config(&chamber.join("cryo.toml"), &cfg).unwrap();
+    crate::registry::set_archived(&chamber, true).unwrap();
+
+    let app = Arc::new(AppState::local_only(workspace.path().to_path_buf()));
+    app.refresh();
+    let id = app.chambers.read().unwrap().keys().next().unwrap().clone();
+
+    let Json(v) = post_unarchive(State(app), AxumPath(id)).await.unwrap();
+
+    assert_eq!(v["ok"], true);
+    assert!(!crate::registry::is_archived(&chamber));
+}
+
 #[test]
 fn status_json_includes_notes_content() {
     let dir = tempfile::tempdir().unwrap();

--- a/src/unit_tests/hub/routes/chamber.rs
+++ b/src/unit_tests/hub/routes/chamber.rs
@@ -8,6 +8,29 @@ fn status_json_for_missing_state_has_zero_session() {
     assert_eq!(v["session"], 0);
 }
 
+#[tokio::test]
+async fn post_start_refuses_archived_chamber_without_launching() {
+    let workspace = tempfile::tempdir().unwrap();
+    let chamber = workspace.path().join("alpha");
+    std::fs::create_dir_all(&chamber).unwrap();
+    let cfg = crate::config::CryoConfig::default();
+    crate::config::save_config(&chamber.join("cryo.toml"), &cfg).unwrap();
+
+    let app = Arc::new(AppState::local_only(workspace.path().to_path_buf()));
+    app.refresh();
+    let id = {
+        let mut idx = app.chambers.write().unwrap();
+        let (id, entry) = idx.iter_mut().next().unwrap();
+        entry.archived = true;
+        id.clone()
+    };
+
+    let Json(v) = post_start(State(app), AxumPath(id)).await.unwrap();
+
+    assert_eq!(v["ok"], false);
+    assert!(v["message"].as_str().unwrap_or("").contains("Unarchive"));
+}
+
 #[test]
 fn status_json_includes_notes_content() {
     let dir = tempfile::tempdir().unwrap();

--- a/src/unit_tests/hub/routes/pages.rs
+++ b/src/unit_tests/hub/routes/pages.rs
@@ -159,12 +159,20 @@ fn shell_only_renders_reset_for_stopped_chambers() {
 }
 
 #[test]
-fn shell_does_not_render_archive_button_in_global_hub() {
+fn shell_renders_archive_for_stopped_chambers_and_unarchive_when_archived() {
+    // #59: stopped chambers can be archived (folded out of the active grid);
+    // archived chambers expose only Unarchive.
     assert!(
-        !SHELL_HTML.contains("confirmArchive")
-            && !SHELL_HTML.contains("/api/chambers/${id}/archive")
-            && !SHELL_HTML.contains("btn('archive'"),
-        "archive is disabled because the hub is global, not workspace-scoped"
+        SHELL_HTML.contains("btn('archive'"),
+        "stopped chambers should expose an Archive button"
+    );
+    assert!(
+        SHELL_HTML.contains("btn('unarchive'"),
+        "archived chambers should expose an Unarchive button"
+    );
+    assert!(
+        SHELL_HTML.contains("Archived (${archived.length})"),
+        "archived chambers should fold into an Archived section in the rail"
     );
 }
 

--- a/src/unit_tests/registry.rs
+++ b/src/unit_tests/registry.rs
@@ -9,6 +9,14 @@ fn scaffold_chamber(parent: &std::path::Path, name: &str) -> std::path::PathBuf 
     dir.canonicalize().unwrap()
 }
 
+fn legacy_raw_entry_filename(dir: &std::path::Path) -> String {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    dir.hash(&mut hasher);
+    format!("{:016x}.json", hasher.finish())
+}
+
 #[test]
 fn test_daemon_entry_has_socket_path() {
     let entry = DaemonEntry {
@@ -149,5 +157,43 @@ fn entry_filename_dedupes_symlinked_path_forms() {
         entry_filename(&real),
         entry_filename(&link),
         "symlinked and real paths must share one registry entry"
+    );
+}
+
+#[test]
+fn list_dedupes_legacy_raw_path_entries_for_same_canonical_chamber() {
+    let state_home = tempfile::tempdir().unwrap();
+    let _guard = EnvVarGuard::set_path("XDG_STATE_HOME", state_home.path());
+    let root = tempfile::tempdir().unwrap();
+    let real = scaffold_chamber(root.path(), "real");
+    let link = root.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    let reg = registry_dir().unwrap();
+    let legacy_path = reg.join(legacy_raw_entry_filename(&link));
+    let legacy_entry = DaemonEntry {
+        pid: None,
+        dir: link.display().to_string(),
+        socket_path: None,
+        archived: false,
+    };
+    std::fs::write(&legacy_path, serde_json::to_string(&legacy_entry).unwrap()).unwrap();
+    set_archived(&real, true).unwrap();
+
+    let entries = list().unwrap();
+    let matching: Vec<_> = entries
+        .iter()
+        .filter(|entry| {
+            std::path::PathBuf::from(&entry.dir)
+                .canonicalize()
+                .is_ok_and(|path| path == real)
+        })
+        .collect();
+
+    assert_eq!(matching.len(), 1, "registry should list one chamber entry");
+    assert!(matching[0].archived, "canonical archived flag should win");
+    assert!(
+        !legacy_path.exists(),
+        "legacy raw-path registry file should be removed"
     );
 }

--- a/src/unit_tests/registry.rs
+++ b/src/unit_tests/registry.rs
@@ -197,3 +197,37 @@ fn list_dedupes_legacy_raw_path_entries_for_same_canonical_chamber() {
         "legacy raw-path registry file should be removed"
     );
 }
+
+#[test]
+fn list_migrates_single_legacy_raw_path_entry_to_canonical_filename() {
+    let state_home = tempfile::tempdir().unwrap();
+    let _guard = EnvVarGuard::set_path("XDG_STATE_HOME", state_home.path());
+    let root = tempfile::tempdir().unwrap();
+    let real = scaffold_chamber(root.path(), "real");
+    let link = root.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    let reg = registry_dir().unwrap();
+    let legacy_path = reg.join(legacy_raw_entry_filename(&link));
+    let canonical_path = reg.join(entry_filename(&real));
+    let legacy_entry = DaemonEntry {
+        pid: None,
+        dir: link.display().to_string(),
+        socket_path: None,
+        archived: true,
+    };
+    std::fs::write(&legacy_path, serde_json::to_string(&legacy_entry).unwrap()).unwrap();
+
+    let entries = list().unwrap();
+
+    assert_eq!(entries.len(), 1);
+    assert!(entries[0].archived);
+    assert!(
+        canonical_path.exists(),
+        "entry should be rewritten canonically"
+    );
+    assert!(
+        !legacy_path.exists(),
+        "legacy raw-path registry file should be removed"
+    );
+}

--- a/src/unit_tests/registry.rs
+++ b/src/unit_tests/registry.rs
@@ -15,6 +15,7 @@ fn test_daemon_entry_has_socket_path() {
         pid: Some(1234),
         dir: "/tmp/test".to_string(),
         socket_path: Some("/tmp/test/.cryo/cryo.sock".to_string()),
+        archived: false,
     };
     let json = serde_json::to_string(&entry).unwrap();
     assert!(json.contains("cryo.sock"));
@@ -70,6 +71,7 @@ fn list_marks_dead_pid_as_stopped_without_forgetting_chamber() {
         pid: Some(999_999_999),
         dir: chamber.display().to_string(),
         socket_path: Some(chamber.join(".cryo/cryo.sock").display().to_string()),
+        archived: false,
     };
     std::fs::write(&entry_path, serde_json::to_string(&entry).unwrap()).unwrap();
 
@@ -91,6 +93,7 @@ fn list_prunes_registry_entries_for_missing_chambers() {
         pid: None,
         dir: missing.display().to_string(),
         socket_path: None,
+        archived: false,
     };
     std::fs::write(&entry_path, serde_json::to_string(&entry).unwrap()).unwrap();
 
@@ -98,4 +101,53 @@ fn list_prunes_registry_entries_for_missing_chambers() {
 
     assert!(entries.is_empty());
     assert!(!entry_path.exists());
+}
+
+#[test]
+fn set_archived_persists_across_register_and_unregister() {
+    let state_home = tempfile::tempdir().unwrap();
+    let _guard = EnvVarGuard::set_path("XDG_STATE_HOME", state_home.path());
+    let workspace = tempfile::tempdir().unwrap();
+    let chamber = scaffold_chamber(workspace.path(), "alpha");
+
+    remember_chamber(&chamber).unwrap();
+    set_archived(&chamber, true).unwrap();
+
+    let archived = |dir: &std::path::Path| {
+        list()
+            .unwrap()
+            .into_iter()
+            .find(|e| e.dir == dir.display().to_string())
+            .unwrap()
+            .archived
+    };
+    assert!(archived(&chamber), "flag set");
+
+    // A daemon start/stop cycle must not clear the flag.
+    register(&chamber, None).unwrap();
+    assert!(archived(&chamber), "survives register");
+    unregister(&chamber);
+    assert!(archived(&chamber), "survives unregister");
+
+    // Only set_archived clears it.
+    set_archived(&chamber, false).unwrap();
+    assert!(!archived(&chamber), "flag cleared");
+}
+
+#[test]
+fn entry_filename_dedupes_symlinked_path_forms() {
+    // A chamber reached through a symlinked path (macOS `/var` -> `/private/var`
+    // is the real-world case) must map to the same registry file, or the hub
+    // ends up with two entries for one chamber and archive flags never stick.
+    let root = tempfile::tempdir().unwrap();
+    let real = root.path().join("real");
+    std::fs::create_dir(&real).unwrap();
+    let link = root.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    assert_eq!(
+        entry_filename(&real),
+        entry_filename(&link),
+        "symlinked and real paths must share one registry entry"
+    );
 }

--- a/templates/web_shell.html
+++ b/templates/web_shell.html
@@ -97,6 +97,7 @@
     detailSeq: 0,
     lifecyclePending: {},
     chamberHistoryOpen: false,
+    chamberArchivedOpen: false,
   };
 
   function urlChamberId() {
@@ -259,7 +260,12 @@
     // attention.
     const active = [];
     const completed = [];
+    const archived = [];
     for (const c of state.chambers) {
+      // Archived is a display state the operator chose explicitly, so it wins
+      // over completion — an archived chamber folds into "Archived" regardless
+      // of plan status.
+      if (c.archived) { archived.push(c); continue; }
       // Group by completion alone. The daemon can still be winding down
       // (running=true) right after `hibernate --complete`; `statusClass` and
       // the header glyph already prioritise "completed" in that window, so
@@ -295,6 +301,22 @@
       summary.textContent = `Completed (${completed.length})`;
       details.appendChild(summary);
       for (const c of completed) details.appendChild(buildChamberRow(c));
+      list.appendChild(details);
+    }
+
+    if (archived.length) {
+      archived.sort((a, b) => a.name.localeCompare(b.name));
+      const details = document.createElement('details');
+      details.className = 'chamber-history';
+      const selectedIsInside = archived.some(c => c.id === state.currentId);
+      if (state.chamberArchivedOpen || selectedIsInside) details.open = true;
+      details.addEventListener('toggle', () => {
+        state.chamberArchivedOpen = details.open;
+      });
+      const summary = document.createElement('summary');
+      summary.textContent = `Archived (${archived.length})`;
+      details.appendChild(summary);
+      for (const c of archived) details.appendChild(buildChamberRow(c));
       list.appendChild(details);
     }
 
@@ -483,11 +505,17 @@
 
   function updateLifecycleButtons(entry) {
     const pending = state.lifecyclePending[entry.id];
-    const sig = `${entry.running}|${!!entry.config_error}|${!!entry.completed}|${!!pending}`;
+    const sig = `${entry.running}|${!!entry.config_error}|${!!entry.completed}|${!!entry.archived}|${!!pending}`;
     if (sig === view.lastLifecycleSig) return;
     view.lastLifecycleSig = sig;
     const btns = view.lifecycleBtns;
     btns.innerHTML = '';
+    // Archived chambers are put away: the only action is to bring them back.
+    // Unarchive leaves the chamber stopped; the operator then presses Launch.
+    if (entry.archived) {
+      btns.appendChild(btn('unarchive', () => lifecycle(entry.id, 'unarchive'), 'primary', pending));
+      return;
+    }
     if (entry.running) {
       btns.appendChild(btn('stop', () => lifecycle(entry.id, 'stop'), '', pending));
     } else if (!entry.config_error && !entry.completed) {
@@ -497,6 +525,9 @@
     }
     if (!entry.running && !entry.config_error) {
       btns.appendChild(btn('reset', () => confirmReset(entry.id, entry.name), 'danger', pending));
+      // Archive is only offered once the daemon is stopped — the natural next
+      // step after Stop. Reversible, so no confirm dialog.
+      btns.appendChild(btn('archive', () => lifecycle(entry.id, 'archive'), '', pending));
     }
   }
 


### PR DESCRIPTION
Closes #59.

## What

Adds reversible chamber archiving to the Cryohub dashboard so operators can tidy the chamber list without deleting anything.

- A **stopped** chamber shows an **Archive** button that folds it out of the active list into a collapsible **Archived** section — no files are moved.
- Archived chambers offer **only Unarchive**, which returns them to the active list (still stopped) so you can Launch again.
- Enforced flow: **Stop → Archive → Unarchive → Launch**. A running chamber can't be archived.

Archived is purely a hub display state stored in the registry; the CLI (`cryo ps`) is unaffected.

## How

- **registry**: `archived` flag on `DaemonEntry` + `set_archived()`. `register`/`unregister`/`remember_chamber` preserve the flag across daemon start/stop cycles, so only explicit archive/unarchive change it.
- **registry (bug fix)**: the entry filename now canonicalizes the chamber dir. Without this, the hub's canonical chamber id and the raw path stored by the New-Chamber route hashed to **two different registry files** (macOS `/var` → `/private/var`), and archiving silently created a second entry while the UI kept showing the first — so the flag never took effect. Caught by driving the real binary end-to-end.
- **hub**: `archive_chamber`/`unarchive_chamber` wrappers (archive refuses while running) + `POST /api/chambers/{id}/archive` and `/unarchive`; `archived` added to the chamber list payload.
- **web UI**: Archived fold in the sidebar; Archive/Unarchive buttons in the detail pane.
- **docs**: documented in the monitor-chambers how-to.

## Testing

- `cargo fmt` + `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: green (478 lib tests + all binaries), including new registry (flag persistence, symlink dedup) and hub lifecycle (toggle, refuse-while-running) tests
- **End-to-end drive** against the real `cryohub` binary in an isolated env: `arch=false → archive → arch=true → unarchive → arch=false`, single registry entry throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)