### PR TITLE
Add Pi and Kimi Code agent support

### DIFF
--- a/.claude/skills/make-plan/SKILL.md
+++ b/.claude/skills/make-plan/SKILL.md
@@ -118,6 +118,8 @@ Only switch when the user names a different agent.
 - **opencode** (default, recommended) — headless coding agent
 - **claude** — Anthropic's Claude CLI
 - **codex** — OpenAI's Codex CLI
+- **pi** — Pi CLI
+- **kimi** — Kimi Code CLI
 - **custom** — any command
 
 Then: API key configuration. The agent process inherits one provider's env via a `[provider]` block in `cryo.toml`:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="docs/logo/logo.svg" alt="cryochamber logo" width="500">
 </p>
 
-**Cryochamber** is a hibernation chamber for AI agents (Claude, OpenCode, Codex). It hibernates an AI agent between sessions and wakes it at the right time, not on a fixed schedule. The agent reads its plan, completes a task, and decides when to wake next. Cryochamber empowers AI agents to run tasks that span days, weeks, or even years, like interstellar travelers in stasis.
+**Cryochamber** is a hibernation chamber for AI agents (Claude, OpenCode, Codex, Pi). It hibernates an AI agent between sessions and wakes it at the right time, not on a fixed schedule. The agent reads its plan, completes a task, and decides when to wake next. Cryochamber empowers AI agents to run tasks that span days, weeks, or even years, like interstellar travelers in stasis.
 
 The goal is to automate long-running activities that are too irregular for cron. A conference deadline slips because submissions are low. A space probe's next burn window depends on orbital mechanics. A code review depends on when the author pushes fixes. Cryochamber lets an AI agent reason about *when* to wake and *what* to do next, with a persistent daemon that manages the lifecycle.
 
@@ -30,7 +30,7 @@ Create a chamber directory:
 mkdir my-chamber && cd my-chamber
 ```
 
-Then start Claude Code, Codex, or OpenCode in that directory and ask:
+Then start Claude Code, Codex, OpenCode, or Pi in that directory and ask:
 
 ```text
 Follow the make-plan skill at https://github.com/GiggleLiu/cryochamber/blob/main/.claude/skills/make-plan/SKILL.md to create a new cryochamber project here.
@@ -53,7 +53,7 @@ logs, messages, TODOs, notes, and lifecycle controls.
 - **Agent-guided hibernation**: the agent decides when to wake next instead of running on a fixed cron schedule.
 - **Folder watching**: configure `watch_dirs` to wake the agent when a folder changes, such as `messages/inbox/` or another project directory.
 - **Crash recovery and reboot persistence**: `cryo start` installs a launchd/systemd service by default, so scheduled sessions survive machine reboots; failed TODO sessions are rescheduled as visible retry attempts with backoff.
-- **Configurable agents**: run OpenCode, Claude Code, Codex, or another command from `cryo.toml`.
+- **Configurable agents**: run OpenCode, Claude Code, Codex, Pi, or another command from `cryo.toml`.
 - **Local and remote monitoring**: use the Cryohub dashboard to monitor chamber status, logs, messages, TODOs, notes, and lifecycle controls in a local browser UI, or talk to a chamber from anywhere via Zulip with `cryo-zulip`. See [Monitor and message a chamber](https://giggleliu.github.io/cryochamber/how-to/monitor-chambers.html).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="docs/logo/logo.svg" alt="cryochamber logo" width="500">
 </p>
 
-**Cryochamber** is a hibernation chamber for AI agents (Claude, OpenCode, Codex, Pi). It hibernates an AI agent between sessions and wakes it at the right time, not on a fixed schedule. The agent reads its plan, completes a task, and decides when to wake next. Cryochamber empowers AI agents to run tasks that span days, weeks, or even years, like interstellar travelers in stasis.
+**Cryochamber** is a hibernation chamber for AI agents (Claude, OpenCode, Codex, Pi, Kimi Code). It hibernates an AI agent between sessions and wakes it at the right time, not on a fixed schedule. The agent reads its plan, completes a task, and decides when to wake next. Cryochamber empowers AI agents to run tasks that span days, weeks, or even years, like interstellar travelers in stasis.
 
 The goal is to automate long-running activities that are too irregular for cron. A conference deadline slips because submissions are low. A space probe's next burn window depends on orbital mechanics. A code review depends on when the author pushes fixes. Cryochamber lets an AI agent reason about *when* to wake and *what* to do next, with a persistent daemon that manages the lifecycle.
 
@@ -30,7 +30,7 @@ Create a chamber directory:
 mkdir my-chamber && cd my-chamber
 ```
 
-Then start Claude Code, Codex, OpenCode, or Pi in that directory and ask:
+Then start Claude Code, Codex, OpenCode, Pi, or Kimi Code in that directory and ask:
 
 ```text
 Follow the make-plan skill at https://github.com/GiggleLiu/cryochamber/blob/main/.claude/skills/make-plan/SKILL.md to create a new cryochamber project here.
@@ -53,7 +53,7 @@ logs, messages, TODOs, notes, and lifecycle controls.
 - **Agent-guided hibernation**: the agent decides when to wake next instead of running on a fixed cron schedule.
 - **Folder watching**: configure `watch_dirs` to wake the agent when a folder changes, such as `messages/inbox/` or another project directory.
 - **Crash recovery and reboot persistence**: `cryo start` installs a launchd/systemd service by default, so scheduled sessions survive machine reboots; failed TODO sessions are rescheduled as visible retry attempts with backoff.
-- **Configurable agents**: run OpenCode, Claude Code, Codex, Pi, or another command from `cryo.toml`.
+- **Configurable agents**: run OpenCode, Claude Code, Codex, Pi, Kimi Code, or another command from `cryo.toml`.
 - **Local and remote monitoring**: use the Cryohub dashboard to monitor chamber status, logs, messages, TODOs, notes, and lifecycle controls in a local browser UI, or talk to a chamber from anywhere via Zulip with `cryo-zulip`. See [Monitor and message a chamber](https://giggleliu.github.io/cryochamber/how-to/monitor-chambers.html).
 
 ## License

--- a/docs/src/explanation/concepts.md
+++ b/docs/src/explanation/concepts.md
@@ -6,7 +6,7 @@
 
 **Daemon.** The daemon owns lifecycle. It sleeps until the next wake, watches the inbox for reactive wakeups, enforces the session timeout, claims due TODOs before each run, and handles fallback replies when the agent does not finish the communication loop cleanly.
 
-**Agent.** The agent is the AI process you configure for the chamber, such as OpenCode, Claude Code, Codex, or Pi. It reads the plan, does the work, decides when to wake next, and talks back to the daemon through `cryo-agent` commands.
+**Agent.** The agent is the AI process you configure for the chamber, such as OpenCode, Claude Code, Codex, Pi, or Kimi Code. It reads the plan, does the work, decides when to wake next, and talks back to the daemon through `cryo-agent` commands.
 
 **Session.** A session is one wake, one agent run, and one return to hibernation. Each session gets chamber context, can read pending inbox messages, can schedule future TODOs, and must either hibernate for another wake or complete the plan.
 

--- a/docs/src/explanation/concepts.md
+++ b/docs/src/explanation/concepts.md
@@ -6,7 +6,7 @@
 
 **Daemon.** The daemon owns lifecycle. It sleeps until the next wake, watches the inbox for reactive wakeups, enforces the session timeout, claims due TODOs before each run, and handles fallback replies when the agent does not finish the communication loop cleanly.
 
-**Agent.** The agent is the AI process you configure for the chamber, such as OpenCode, Claude Code, or Codex. It reads the plan, does the work, decides when to wake next, and talks back to the daemon through `cryo-agent` commands.
+**Agent.** The agent is the AI process you configure for the chamber, such as OpenCode, Claude Code, Codex, or Pi. It reads the plan, does the work, decides when to wake next, and talks back to the daemon through `cryo-agent` commands.
 
 **Session.** A session is one wake, one agent run, and one return to hibernation. Each session gets chamber context, can read pending inbox messages, can schedule future TODOs, and must either hibernate for another wake or complete the plan.
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # Cryochamber
 
-**Cryochamber** is a hibernation chamber for AI agents (Claude, OpenCode, Codex). It hibernates an AI agent between sessions and wakes it at the right time, not on a fixed schedule. The agent reads its plan, completes a task, and decides when to wake next. Cryochamber empowers AI agents to run tasks that span days, weeks, or even years, like interstellar travelers in stasis.
+**Cryochamber** is a hibernation chamber for AI agents (Claude, OpenCode, Codex, Pi). It hibernates an AI agent between sessions and wakes it at the right time, not on a fixed schedule. The agent reads its plan, completes a task, and decides when to wake next. Cryochamber empowers AI agents to run tasks that span days, weeks, or even years, like interstellar travelers in stasis.
 
 The goal is to automate long-running activities that are too irregular for cron. A conference deadline slips because submissions are low. A space probe's next burn window depends on orbital mechanics. A code review depends on when the author pushes fixes. Cryochamber lets an AI agent reason about *when* to wake and *what* to do next, with a persistent daemon that manages the lifecycle.
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,6 +1,6 @@
 # Cryochamber
 
-**Cryochamber** is a hibernation chamber for AI agents (Claude, OpenCode, Codex, Pi). It hibernates an AI agent between sessions and wakes it at the right time, not on a fixed schedule. The agent reads its plan, completes a task, and decides when to wake next. Cryochamber empowers AI agents to run tasks that span days, weeks, or even years, like interstellar travelers in stasis.
+**Cryochamber** is a hibernation chamber for AI agents (Claude, OpenCode, Codex, Pi, Kimi Code). It hibernates an AI agent between sessions and wakes it at the right time, not on a fixed schedule. The agent reads its plan, completes a task, and decides when to wake next. Cryochamber empowers AI agents to run tasks that span days, weeks, or even years, like interstellar travelers in stasis.
 
 The goal is to automate long-running activities that are too irregular for cron. A conference deadline slips because submissions are low. A space probe's next burn window depends on orbital mechanics. A code review depends on when the author pushes fixes. Cryochamber lets an AI agent reason about *when* to wake and *what* to do next, with a persistent daemon that manages the lifecycle.
 

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -6,7 +6,7 @@ Each chamber is configured through a `cryo.toml` file in its directory. `cryo in
 
 ```toml
 # cryo.toml — cryochamber project configuration
-agent = "opencode"               # Agent command (opencode, claude, codex, pi, ...)
+agent = "opencode"               # Agent command (opencode, claude, codex, pi, kimi, ...)
 max_session_duration = 3600      # Session timeout in seconds (0 = no timeout)
 watch_dirs = ["messages/inbox"]  # Directories to watch for reactive wake ([] disables)
 zulip_poll_interval = 5          # Zulip sync poll interval in seconds
@@ -20,7 +20,7 @@ env = { ANTHROPIC_API_KEY = "sk-ant-..." }  # Env vars set when spawning the age
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `agent` | `"opencode"` | Agent command to run. Use `"claude"` for Claude Code, `"codex"` for Codex, `"pi"` for Pi, or any executable on `PATH`. |
+| `agent` | `"opencode"` | Agent command to run. Use `"claude"` for Claude Code, `"codex"` for Codex, `"pi"` for Pi, `"kimi"` for Kimi Code, or any executable on `PATH`. |
 | `max_session_duration` | `3600` | Session timeout in seconds. `0` disables the timeout. |
 | `watch_dirs` | `["messages/inbox"]` | List of directories the daemon watches for new files to wake the agent reactively. Paths are interpreted relative to the chamber directory unless absolute. Set to `[]` to disable reactive wake entirely. |
 | `zulip_poll_interval` | `5` | How often `cryo-zulip sync` polls Zulip, in seconds. `cryo-zulip sync --interval N` overrides it for one run. |

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -6,7 +6,7 @@ Each chamber is configured through a `cryo.toml` file in its directory. `cryo in
 
 ```toml
 # cryo.toml — cryochamber project configuration
-agent = "opencode"               # Agent command (opencode, claude, codex, ...)
+agent = "opencode"               # Agent command (opencode, claude, codex, pi, ...)
 max_session_duration = 3600      # Session timeout in seconds (0 = no timeout)
 watch_dirs = ["messages/inbox"]  # Directories to watch for reactive wake ([] disables)
 zulip_poll_interval = 5          # Zulip sync poll interval in seconds
@@ -20,7 +20,7 @@ env = { ANTHROPIC_API_KEY = "sk-ant-..." }  # Env vars set when spawning the age
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `agent` | `"opencode"` | Agent command to run. Use `"claude"` for Claude Code, `"codex"` for Codex, or any executable on `PATH`. |
+| `agent` | `"opencode"` | Agent command to run. Use `"claude"` for Claude Code, `"codex"` for Codex, `"pi"` for Pi, or any executable on `PATH`. |
 | `max_session_duration` | `3600` | Session timeout in seconds. `0` disables the timeout. |
 | `watch_dirs` | `["messages/inbox"]` | List of directories the daemon watches for new files to wake the agent reactively. Paths are interpreted relative to the chamber directory unless absolute. Set to `[]` to disable reactive wake entirely. |
 | `zulip_poll_interval` | `5` | How often `cryo-zulip sync` polls Zulip, in seconds. `cryo-zulip sync --interval N` overrides it for one run. |

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -7,7 +7,7 @@ You only need this tutorial. Reference and how-to pages are linked at the end.
 ## Prerequisites
 
 - The Rust toolchain. Install from [rustup.rs](https://rustup.rs).
-- An AI coding agent on your `PATH`: [OpenCode](https://github.com/opencode-ai/opencode), default, [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), or [Pi](https://pi.dev).
+- An AI coding agent on your `PATH`: [OpenCode](https://github.com/opencode-ai/opencode), default, [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), [Pi](https://pi.dev), or [Kimi Code](https://www.kimi.com/code).
 - macOS or Linux. Windows is not supported.
 
 ## Step 1: Install cryochamber

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -7,7 +7,7 @@ You only need this tutorial. Reference and how-to pages are linked at the end.
 ## Prerequisites
 
 - The Rust toolchain. Install from [rustup.rs](https://rustup.rs).
-- An AI coding agent on your `PATH`: [OpenCode](https://github.com/opencode-ai/opencode), default, [Claude Code](https://docs.anthropic.com/en/docs/claude-code), or [Codex](https://github.com/openai/codex).
+- An AI coding agent on your `PATH`: [OpenCode](https://github.com/opencode-ai/opencode), default, [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex), or [Pi](https://pi.dev).
 - macOS or Linux. Windows is not supported.
 
 ## Step 1: Install cryochamber

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -15,6 +15,8 @@ enum AgentKind {
     Codex,
     /// Pi: `pi [flags] -p <prompt>`
     Pi,
+    /// Kimi Code: `kimi [flags] -p <prompt>`
+    Kimi,
     /// Mock agent: invokes the `cryo-mock` binary, which reads
     /// `./scenario.toml` and dispatches the declarative action list.
     Mock,
@@ -29,6 +31,7 @@ enum AgentKind {
 ///   "codex"     → "codex exec"     (bare codex starts interactive TUI)
 ///   "claude"    → "claude -p"      (needs -p flag for non-interactive mode)
 ///   "pi"        → "pi -p"          (needs -p flag for non-interactive mode)
+///   "kimi"      → "kimi -p"        (needs -p flag for non-interactive mode)
 ///
 /// Unknown programs are treated as custom agents (prompt passed as positional arg).
 fn resolve_agent(agent_cmd: &str) -> Result<(AgentKind, String, Vec<String>)> {
@@ -62,6 +65,7 @@ fn resolve_agent(agent_cmd: &str) -> Result<(AgentKind, String, Vec<String>)> {
             Ok((AgentKind::Codex, program.clone(), full_args))
         }
         "pi" => Ok((AgentKind::Pi, program.clone(), args)),
+        "kimi" => Ok((AgentKind::Kimi, program.clone(), args)),
         "mock" => Ok((AgentKind::Mock, "cryo-mock".to_string(), vec![])),
         _ => Ok((AgentKind::Custom, program.clone(), args)),
     }
@@ -217,6 +221,11 @@ pub fn build_command(agent_command: &str, prompt: &str) -> Result<Command> {
         }
         AgentKind::Pi => {
             if !args.iter().any(|arg| arg == "-p") {
+                cmd.arg("-p");
+            }
+        }
+        AgentKind::Kimi => {
+            if !args.iter().any(|arg| arg == "-p" || arg == "--prompt") {
                 cmd.arg("-p");
             }
         }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -13,6 +13,8 @@ enum AgentKind {
     Opencode,
     /// Codex: `codex exec [flags] <prompt>`
     Codex,
+    /// Pi: `pi [flags] -p <prompt>`
+    Pi,
     /// Mock agent: invokes the `cryo-mock` binary, which reads
     /// `./scenario.toml` and dispatches the declarative action list.
     Mock,
@@ -26,6 +28,7 @@ enum AgentKind {
 ///   "opencode"  → "opencode run"   (bare opencode starts interactive TUI)
 ///   "codex"     → "codex exec"     (bare codex starts interactive TUI)
 ///   "claude"    → "claude -p"      (needs -p flag for non-interactive mode)
+///   "pi"        → "pi -p"          (needs -p flag for non-interactive mode)
 ///
 /// Unknown programs are treated as custom agents (prompt passed as positional arg).
 fn resolve_agent(agent_cmd: &str) -> Result<(AgentKind, String, Vec<String>)> {
@@ -58,6 +61,7 @@ fn resolve_agent(agent_cmd: &str) -> Result<(AgentKind, String, Vec<String>)> {
             }
             Ok((AgentKind::Codex, program.clone(), full_args))
         }
+        "pi" => Ok((AgentKind::Pi, program.clone(), args)),
         "mock" => Ok((AgentKind::Mock, "cryo-mock".to_string(), vec![])),
         _ => Ok((AgentKind::Custom, program.clone(), args)),
     }
@@ -207,6 +211,11 @@ pub fn build_command(agent_command: &str, prompt: &str) -> Result<Command> {
 
     match kind {
         AgentKind::Claude => {
+            if !args.iter().any(|arg| arg == "-p") {
+                cmd.arg("-p");
+            }
+        }
+        AgentKind::Pi => {
             if !args.iter().any(|arg| arg == "-p") {
                 cmd.arg("-p");
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ pub struct ProviderConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CryoConfig {
-    /// Agent command (e.g. "opencode", "claude", "codex", "pi")
+    /// Agent command (e.g. "opencode", "claude", "codex", "pi", "kimi")
     #[serde(default = "default_agent")]
     pub agent: String,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ pub struct ProviderConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CryoConfig {
-    /// Agent command (e.g. "opencode", "claude", "codex")
+    /// Agent command (e.g. "opencode", "claude", "codex", "pi")
     #[serde(default = "default_agent")]
     pub agent: String,
 

--- a/templates/cryo.toml
+++ b/templates/cryo.toml
@@ -1,6 +1,6 @@
 # cryo.toml — Cryochamber project configuration
 
-# Agent command (e.g. "opencode", "claude", "codex")
+# Agent command (e.g. "opencode", "claude", "codex", "pi")
 agent = "{{agent}}"
 
 # Session timeout in seconds (0 = no timeout)

--- a/templates/cryo.toml
+++ b/templates/cryo.toml
@@ -1,6 +1,6 @@
 # cryo.toml — Cryochamber project configuration
 
-# Agent command (e.g. "opencode", "claude", "codex", "pi")
+# Agent command (e.g. "opencode", "claude", "codex", "pi", "kimi")
 agent = "{{agent}}"
 
 # Session timeout in seconds (0 = no timeout)

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -294,6 +294,37 @@ fn test_mock_agent_program() {
 }
 
 #[test]
+fn test_build_command_pi_injects_print_flag() {
+    let cmd = cryochamber::agent::build_command("pi", "test prompt").unwrap();
+    let program = cmd.get_program().to_string_lossy();
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(program, "pi");
+    assert_eq!(args, vec!["-p", "test prompt"]);
+}
+
+#[test]
+fn test_build_command_pi_print_flag_is_idempotent() {
+    let cmd = cryochamber::agent::build_command("pi --name nightly -p", "test prompt").unwrap();
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(args.iter().filter(|arg| arg.as_str() == "-p").count(), 1);
+    assert_eq!(args.last().map(String::as_str), Some("test prompt"));
+}
+
+#[test]
+fn test_pi_agent_program() {
+    let program = cryochamber::agent::agent_program("pi").unwrap();
+    assert_eq!(program, "pi");
+}
+
+#[test]
 fn test_build_command_claude_p_flag_is_idempotent() {
     let cmd = cryochamber::agent::build_command("claude -p", "test prompt").unwrap();
     let args: Vec<String> = cmd

--- a/tests/agent_tests.rs
+++ b/tests/agent_tests.rs
@@ -325,6 +325,68 @@ fn test_pi_agent_program() {
 }
 
 #[test]
+fn test_build_command_kimi_injects_prompt_flag() {
+    let cmd = cryochamber::agent::build_command("kimi", "test prompt").unwrap();
+    let program = cmd.get_program().to_string_lossy();
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(program, "kimi");
+    assert_eq!(args, vec!["-p", "test prompt"]);
+}
+
+#[test]
+fn test_build_command_kimi_matches_path_basename() {
+    let cmd = cryochamber::agent::build_command("/opt/kimi/bin/kimi", "test prompt").unwrap();
+    let program = cmd.get_program().to_string_lossy();
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(program, "/opt/kimi/bin/kimi");
+    assert_eq!(args, vec!["-p", "test prompt"]);
+}
+
+#[test]
+fn test_build_command_kimi_prompt_flag_is_idempotent() {
+    let cmd =
+        cryochamber::agent::build_command("kimi -m kimi-code/kimi-for-coding -p", "test prompt")
+            .unwrap();
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(args.iter().filter(|arg| arg.as_str() == "-p").count(), 1);
+    assert_eq!(args.last().map(String::as_str), Some("test prompt"));
+}
+
+#[test]
+fn test_build_command_kimi_long_prompt_flag_is_idempotent() {
+    let cmd = cryochamber::agent::build_command("kimi --prompt", "test prompt").unwrap();
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect();
+
+    assert!(!args.iter().any(|arg| arg == "-p"));
+    assert_eq!(
+        args.iter().filter(|arg| arg.as_str() == "--prompt").count(),
+        1
+    );
+    assert_eq!(args.last().map(String::as_str), Some("test prompt"));
+}
+
+#[test]
+fn test_kimi_agent_program() {
+    let program = cryochamber::agent::agent_program("kimi").unwrap();
+    assert_eq!(program, "kimi");
+}
+
+#[test]
 fn test_build_command_claude_p_flag_is_idempotent() {
     let cmd = cryochamber::agent::build_command("claude -p", "test prompt").unwrap();
     let args: Vec<String> = cmd


### PR DESCRIPTION
## Summary
- Treat `pi` and `kimi` as known Cryochamber agents and inject `-p` for non-interactive prompt mode.
- Keep `pi -p`, `kimi -p`, and `kimi --prompt` handling idempotent when users pass their own flags.
- Document Pi and Kimi Code in supported-agent examples, the configuration template, and the bundled make-plan skill.

## Test Plan
- [x] `cargo test --test agent_tests kimi`
- [x] `cargo test --test agent_tests`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo install --path .`
- [x] `cryo init --agent kimi` smoke check

## Local Full-Suite Note
- Full `cargo test` is blocked in this environment by watcher/inotify exhaustion (`Too many open files`, with `/proc/sys/fs/inotify/max_user_instances` set to 128). The failure was present before this change and affects watcher tests only.