### PR TITLE
fix: skip archived chambers in hub watchers

### DIFF
--- a/src/hub/state.rs
+++ b/src/hub/state.rs
@@ -1,10 +1,8 @@
 //! Shared application state for the web server.
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
-
-#[cfg(not(test))]
-use std::collections::BTreeSet;
 
 use crate::hub::discovery::{ChamberEntry, ChamberIndex, DiscoveryOptions};
 
@@ -39,6 +37,16 @@ pub struct AppState {
     pub chambers: Arc<RwLock<ChamberIndex>>,
     pub tx: tokio::sync::broadcast::Sender<SseEvent>,
     pub watchers: crate::hub::watchers::WatcherRegistry,
+}
+
+fn watcher_targets(idx: &ChamberIndex) -> (BTreeSet<PathBuf>, Vec<(String, PathBuf)>) {
+    let entries: Vec<(String, PathBuf)> = idx
+        .values()
+        .filter(|entry| !entry.archived)
+        .map(|entry| (entry.id.clone(), entry.path.clone()))
+        .collect();
+    let paths = entries.iter().map(|(_, path)| path.clone()).collect();
+    (paths, entries)
 }
 
 impl AppState {
@@ -119,12 +127,7 @@ impl AppState {
     pub fn wire_watchers(&self) {
         let (paths, entries): (BTreeSet<PathBuf>, Vec<(String, PathBuf)>) = {
             let idx = self.chambers.read().unwrap();
-            let paths: BTreeSet<PathBuf> = idx.values().map(|e| e.path.clone()).collect();
-            let entries: Vec<(String, PathBuf)> = idx
-                .values()
-                .map(|e| (e.id.clone(), e.path.clone()))
-                .collect();
-            (paths, entries)
+            watcher_targets(&idx)
         };
         for (id, path) in entries {
             self.watchers.ensure_watching(id, &path, self.tx.clone());

--- a/src/unit_tests/hub/state.rs
+++ b/src/unit_tests/hub/state.rs
@@ -1,5 +1,50 @@
 use super::*;
 
+fn chamber_entry(id: &str, path: std::path::PathBuf, archived: bool) -> ChamberEntry {
+    ChamberEntry {
+        id: id.to_string(),
+        name: id.to_string(),
+        path,
+        path_hint: None,
+        config_error: None,
+        running: false,
+        agent_running: false,
+        session: None,
+        next_wake: None,
+        next_wake_display: None,
+        wake_imminent: false,
+        has_open_question: false,
+        task: None,
+        last_message_preview: None,
+        completed: false,
+        archived,
+        sync: Vec::new(),
+    }
+}
+
+#[test]
+fn watcher_targets_skip_archived_chambers() {
+    let active_path = std::path::PathBuf::from("/tmp/active");
+    let archived_path = std::path::PathBuf::from("/tmp/archived");
+    let mut idx = ChamberIndex::new();
+    idx.insert(
+        "active".to_string(),
+        chamber_entry("active", active_path.clone(), false),
+    );
+    idx.insert(
+        "archived".to_string(),
+        chamber_entry("archived", archived_path, true),
+    );
+
+    let (paths, entries) = watcher_targets(&idx);
+
+    assert_eq!(
+        paths,
+        std::collections::BTreeSet::from([active_path.clone()])
+    );
+    assert_eq!(entries, vec![("active".to_string(), active_path)]);
+}
+
 #[test]
 fn resolve_finds_known_chamber() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- Filter archived chambers out of Cryohub watcher targets.
- Use the same filtered target list for watcher creation and retention so archived chambers drop existing watchers on refresh.
- Add a regression test for active-only watcher target selection.

## Root cause
Cryohub discovery keeps registry entries for archived chambers, but AppState::wire_watchers previously watched every entry in the index and retained every path. Archived chambers therefore continued to consume notify/inotify watcher instances even though the dashboard folds them away and refuses to start them.

## Verification
- cargo fmt --all
- cargo build
- cargo clippy --all-targets -- -D warnings
- cargo test --lib hub::state::tests::watcher_targets_skip_archived_chambers
- cargo test --lib hub::state::tests
- RUST_TEST_THREADS=1 cargo test

Review subagent: no findings; noted the intentional limitation that wire_watchers is cfg(test) no-op, so the regression tests the extracted target selector directly.